### PR TITLE
internal/ci: test CLs by using PRs

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -4,7 +4,6 @@ name: TryBot
 "on":
   push:
     branches:
-      - trybot/*/*/*/*
       - master
       - ci/test
   pull_request: {}

--- a/.github/workflows/trybot_dispatch.yml
+++ b/.github/workflows/trybot_dispatch.yml
@@ -33,4 +33,8 @@ jobs:
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
           git fetch https://review.gerrithub.io/a/cue-lang/cuelang.org ${{ github.event.client_payload.payload.ref }}
           git checkout -b trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }} FETCH_HEAD
-          git push https://github.com/cue-lang/cuelang.org-trybot trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}
+          git remote add origin https://github.com/cue-lang/cuelang.org-trybot
+          git fetch origin ${{ github.event.client_payload.payload.branch }}
+          git push origin trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}
+          echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
+          gh pr create -B ${{ github.event.client_payload.payload.branch }} -f

--- a/internal/ci/gerrithub/gerrithub.cue
+++ b/internal/ci/gerrithub/gerrithub.cue
@@ -85,7 +85,11 @@ _#linuxMachine: "ubuntu-20.04"
 						git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n \(#botGitHubUser):${{ secrets.\(#botGitHubUserTokenSecretsKey) }} | base64)"
 						git fetch \(#gerritHubRepository) ${{ github.event.client_payload.payload.ref }}
 						git checkout -b \(_#branchNameExpression) FETCH_HEAD
-						git push \(#trybotRepositoryURL) \(_#branchNameExpression)
+						git remote add origin \(#trybotRepositoryURL)
+						git fetch origin ${{ github.event.client_payload.payload.branch }}
+						git push origin \(_#branchNameExpression)
+						echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
+						gh pr create -B ${{ github.event.client_payload.payload.branch }} -f
 						"""
 				},
 			]

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -37,7 +37,7 @@ trybot: _base.#bashWorkflow & {
 
 	on: {
 		push: {
-			branches: ["trybot/*/*/*/*", _#defaultBranch, _base.#testDefaultBranch] // do not run PR branches
+			branches: [_#defaultBranch, _base.#testDefaultBranch]
 		}
 		pull_request: {}
 	}


### PR DESCRIPTION
By testing CLs via PRs, we can use the fact that a PR has a target
branch. This allows the PR workflow test to use the target branch
actions cache. This is especially significant for the alpha branch
because it is not the default branch.

See the logic in:

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key

for details on how the action cache is chosen, and why the target branch
is important for CLs that target alpha.

We remove the running of trybots on pushes to branches matching the
trybot/*/*/*/* format in a later CL, otherwise we cannot run the trybots
for this CL.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I128f8e6a1981be4dad035e8e9ff9f53e5569d636
