### PR TITLE
internal/ci: push all active branches from main to trybot repos

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -5,6 +5,7 @@ name: TryBot
   push:
     branches:
       - master
+      - alpha
       - ci/test
   pull_request: {}
 jobs:

--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -32,8 +32,8 @@ jobs:
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
           git remote add origin https://review.gerrithub.io/a/cue-lang/cuelang.org
           git remote add trybot https://github.com/cue-lang/cuelang.org-trybot
-          git fetch origin master
-          git push trybot refs/remotes/origin/master:master
+          git fetch origin
+          git push trybot "refs/remotes/origin/*:refs/heads/*"
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -37,7 +37,7 @@ trybot: _base.#bashWorkflow & {
 
 	on: {
 		push: {
-			branches: [_#defaultBranch, _base.#testDefaultBranch]
+			branches: [ for v in _#activeBranches {v}, _base.#testDefaultBranch]
 		}
 		pull_request: {}
 	}

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -49,8 +49,8 @@ update_tip: _base.#bashWorkflow & {
 						git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n \(_gerrithub.#botGitHubUser):${{ secrets.\(_gerrithub.#botGitHubUserTokenSecretsKey) }} | base64)"
 						git remote add origin \(_gerrithub.#gerritHubRepository)
 						git remote add trybot \(_gerrithub.#trybotRepositoryURL)
-						git fetch origin \(_#defaultBranch)
-						git push trybot refs/remotes/origin/master:master
+						git fetch origin
+						git push trybot "refs/remotes/origin/*:refs/heads/*"
 						"""
 			},
 			_base.#checkoutCode & {

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -50,6 +50,8 @@ workflows: [
 _#defaultBranch:     "master"
 _#releaseTagPattern: "v*"
 
+_#activeBranches: [_#defaultBranch, "alpha"]
+
 // Use the latest Go version for extra checks,
 // such as running tests with the data race detector.
 _#latestStableGo: "1.19.x"


### PR DESCRIPTION
Also keep track of active development branches so that workflows etc can
reference that list. This allows us to fix the fact that alpha should
also build in response to push commits.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I4c117ab577758fdec4c58462a630731685192671
