### PR TITLE
internal/ci: make push_tip_to_trybot a separate workflow

### DIFF
--- a/.github/workflows/push_tip_to_trybot.yml
+++ b/.github/workflows/push_tip_to_trybot.yml
@@ -1,0 +1,37 @@
+# Code generated internal/ci/ci_tool.cue; DO NOT EDIT.
+
+name: Push tip to trybot
+"on":
+  push:
+    branches:
+      - master
+      - alpha
+concurrency: push_tip_to_trybot
+jobs:
+  push:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+    if: ${{github.repository == 'cue-lang/cuelang.org'}}
+    steps:
+      - name: Write netrc file for cueckoo Gerrithub
+        run: |-
+          cat <<EOD > ~/.netrc
+          machine review.gerrithub.io
+          login cueckoo
+          password ${{ secrets.CUECKOO_GERRITHUB_PASSWORD }}
+          EOD
+          chmod 600 ~/.netrc
+      - name: Push tip to trybot
+        run: |-
+          mkdir tmpgit
+          cd tmpgit
+          git init
+          git config user.name cueckoo
+          git config user.email cueckoo@gmail.com
+          git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
+          git remote add origin https://review.gerrithub.io/a/cue-lang/cuelang.org
+          git remote add trybot https://github.com/cue-lang/cuelang.org-trybot
+          git fetch origin master alpha
+          git push trybot "refs/remotes/origin/*:refs/heads/*"

--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -22,18 +22,6 @@ jobs:
           password ${{ secrets.CUECKOO_GERRITHUB_PASSWORD }}
           EOD
           chmod 600 ~/.netrc
-      - name: Push tip to trybot
-        run: |-
-          mkdir tmpgit
-          cd tmpgit
-          git init
-          git config user.name cueckoo
-          git config user.email cueckoo@gmail.com
-          git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
-          git remote add origin https://review.gerrithub.io/a/cue-lang/cuelang.org
-          git remote add trybot https://github.com/cue-lang/cuelang.org-trybot
-          git fetch origin master alpha
-          git push trybot "refs/remotes/origin/*:refs/heads/*"
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -1,0 +1,58 @@
+// Copyright 2023 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"strings"
+
+	"github.com/cue-lang/cuelang.org/internal/ci/core"
+
+	"github.com/SchemaStore/schemastore/src/schemas/json"
+)
+
+// push_tip_to_trybot "syncs" active branches to the trybot repo
+push_tip_to_trybot: _base.#bashWorkflow & {
+
+	name: "Push tip to trybot"
+	on: {
+		push: branches: _#activeBranches
+	}
+
+	concurrency: "push_tip_to_trybot"
+
+	jobs: push: {
+		"runs-on": _#linuxMachine
+		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		steps: [
+			_gerrithub.#writeNetrcFile,
+			json.#step & {
+				name: "Push tip to trybot"
+				run:  """
+						mkdir tmpgit
+						cd tmpgit
+						git init
+						git config user.name \(_gerrithub.#botGitHubUser)
+						git config user.email \(_gerrithub.#botGitHubUserEmail)
+						git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n \(_gerrithub.#botGitHubUser):${{ secrets.\(_gerrithub.#botGitHubUserTokenSecretsKey) }} | base64)"
+						git remote add origin \(_gerrithub.#gerritHubRepository)
+						git remote add trybot \(_gerrithub.#trybotRepositoryURL)
+						git fetch origin \(strings.Join(_#activeBranches, " "))
+						git push trybot "refs/remotes/origin/*:refs/heads/*"
+						"""
+			},
+		]
+	}
+
+}

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -15,11 +15,7 @@
 package github
 
 import (
-	"strings"
-
 	"github.com/cue-lang/cuelang.org/internal/ci/core"
-
-	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
 // The update_tip workflow. Keeps the tip branch in "sync" with master.
@@ -40,21 +36,6 @@ update_tip: _base.#bashWorkflow & {
 		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
 		steps: [
 			_gerrithub.#writeNetrcFile,
-			json.#step & {
-				name: "Push tip to trybot"
-				run:  """
-						mkdir tmpgit
-						cd tmpgit
-						git init
-						git config user.name \(_gerrithub.#botGitHubUser)
-						git config user.email \(_gerrithub.#botGitHubUserEmail)
-						git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n \(_gerrithub.#botGitHubUser):${{ secrets.\(_gerrithub.#botGitHubUserTokenSecretsKey) }} | base64)"
-						git remote add origin \(_gerrithub.#gerritHubRepository)
-						git remote add trybot \(_gerrithub.#trybotRepositoryURL)
-						git fetch origin \(strings.Join(_#activeBranches, " "))
-						git push trybot "refs/remotes/origin/*:refs/heads/*"
-						"""
-			},
 			_base.#checkoutCode & {
 				with: ref: _#defaultBranch
 			},

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -45,6 +45,10 @@ workflows: [
 		file:   "update_tip.yml"
 		schema: update_tip
 	},
+	{
+		file:   "push_tip_to_trybot.yml"
+		schema: push_tip_to_trybot
+	},
 ]
 
 _#defaultBranch:     "master"


### PR DESCRIPTION
This more easily allows us to run it for all active branches.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ic503b0f39da802b5beb11b1a1caa9f9be59af38d
