### PR TITLE
internal/ci: make action cache key unique

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -25,7 +25,8 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
             ~/.npm
-          key: ${{ runner.os }}
+          key: ${{ runner.os }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}
       - name: Install Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -32,7 +32,8 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
             ~/.npm
-          key: ${{ runner.os }}
+          key: ${{ runner.os }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}
       - name: Install Node
         uses: actions/setup-node@v3
         with:

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -110,7 +110,13 @@ _#cachePre: json.#step & {
 	uses: "actions/cache@v3"
 	with: {
 		path: strings.Join(_#cacheDirs, "\n")
-		key:  "${{ runner.os }}"
+
+		// GitHub actions caches are immutable. Therefore, use a key which is
+		// unique, but allow the restore to fallback to the most recent cache.
+		// The result is then saved under the new key which will benefit the
+		// next build
+		key:            "${{ runner.os }}-${{ github.run_id }}"
+		"restore-keys": "${{ runner.os }}"
 	}
 }
 


### PR DESCRIPTION
GitHub actions caches are immutable. Therefore, use a key which is
unique, but allow the restore to fallback to the most recent cache.
The result is then saved under the new key which will benefit the
next build

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ibbf5eb53f96064bbd41d163d968e51053037d42f
