### PR TITLE
gerritstatusupdater: do not try to do anything with non-CL branches

### DIFF
--- a/internal/functions/gerritstatusupdater/gerritstatusupdater.go
+++ b/internal/functions/gerritstatusupdater/gerritstatusupdater.go
@@ -242,7 +242,11 @@ func (c *localContext) setHeadBranch(b string) {
 	// We don't limit the branch to only be three parts so as to
 	// allow for extending the format in some cases.
 	headBranchParts := strings.Split(c.HeadBranch, "/")
-	if len(headBranchParts) < 3 {
+	switch x := len(headBranchParts); {
+	case x == 1:
+		log.Printf("nothing to do on branch %q", c.HeadBranch)
+		panic(nil) // early return from handler
+	case x < 3:
 		panic(fmt.Errorf("head branch %q not in expected format", c.HeadBranch))
 	}
 	c.ChangeID, c.RevisionID = headBranchParts[1], headBranchParts[2]


### PR DESCRIPTION
Now that we also build non-CL branches in the trybot repo, we need to
ignore events for those branches.

For now, we identify such branches by the absence of a '/'. This is
fairly reasonable, because as repository owners we are in control of all
branches created in this repo.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I04a5cf0d28ef5e098e25c4e0f85709e9cffb4f90
