### PR TITLE
internal/ci: allow tip deploy to be triggered by repository_dispatch

### DIFF
--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -5,6 +5,7 @@ name: Update tip
   push:
     branches:
       - master
+  repository_dispatch: {}
 concurrency: deploy
 jobs:
   push:
@@ -12,7 +13,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    if: ${{github.repository == 'cue-lang/cuelang.org'}}
+    if: ${{ github.repository == 'cue-lang/cuelang.org' && (github.event_name != 'repository_dispatch' || github.event.client_payload.type == 'rebuild_tip') }}
     steps:
       - name: Write netrc file for cueckoo Gerrithub
         run: |-


### PR DESCRIPTION
Now that tip.cuelang.org is its own site, deployed from a workflow in
this repo (as opposed to a job that runs on Netlify), we need to be able
to trigger that workflow from other places.  Specifically, we need to be
able to trigger a deploy when we get a new commit at the tip of
cue-lang/cue.

Therefore we update the update_tip workflow in this repository_dispatch
to be trigger-able via repository_dispatch.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I08c2a7a5c1382da642fca4a5ee0503583066d42c
