### PR TITLE
internal/ci/netlify: make CL redirect non-repo specific

### DIFF
--- a/internal/ci/netlify/netlify.cue
+++ b/internal/ci/netlify/netlify.cue
@@ -65,7 +65,7 @@ config: #config & {
 	redirects: [...{force: true, status: 302}]
 	redirects: [{
 		from: "/cl/*"
-		to:   "https://review.gerrithub.io/c/cue-lang/cue/+/:splat"
+		to:   "https://review.gerrithub.io/c/:splat"
 	}, {
 		from: "/issue/*"
 		to:   "https://github.com/cue-lang/cue/issues/:splat"

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@ command = "bash build.bash -b $DEPLOY_URL"
 
 [[redirects]]
   from = "/cl/*"
-  to = "https://review.gerrithub.io/c/cue-lang/cue/+/:splat"
+  to = "https://review.gerrithub.io/c/:splat"
   status = 302
   force = true
 


### PR DESCRIPTION
This allows cuelang.org/cl/N to redirect to the corresponding GerritHub
CL regardless of repo.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I01890bdd749f2cbbd6e7c420f4c0c167904fd5d3
Reviewed-on: https://review.gerrithub.io/c/cue-lang/cuelang.org/+/550022
Reviewed-by: Daniel Martí <mvdan@mvdan.cc>
TryBot-Result: CUEcueckoo <cueckoo@cuelang.org>
(cherry picked from commit 06aa208566f4f8094c445934ad3d5f0099c07faa)
