### PR TITLE
internal/ci: manually enforce DCO check

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -43,6 +43,34 @@ jobs:
           	echo "second line of commit message must be blank"
           	exit 1
           fi
+
+          # Ensure that the commit author is the same as the signed-off-by.  This
+          # is a basic requirement of DCO. It is enforced by Gerrit (although
+          # noting that in Gerrit the author name does not have to match, only
+          # the email address), but _not_ by the DCO GitHub app:
+          #
+          #   https://github.com/dcoapp/app/issues/201
+          #
+          # Provide a sanity check as part of GitHub workflows that should enforce
+          # this, e.g. trybot workflows.
+          #
+          # We do so by comparing the commit author and "Signed-off-by" trailer for
+          # strict equality. Whilst this is more strict than Gerrit, it should
+          # generally be the case, and we can always relax this when presented with
+          # specific situations where it is is a problem.
+
+          # commit author
+          commitauthor="$(git log -1 --pretty="%an <%ae>")"
+
+          # signed-off-by trailer
+          # Getting the Signed-off-by trailer in this way causes blank
+          # lines for some reason. Use awk to remove them.
+          commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | awk NF)"
+
+          if [ "$commitauthor" != "$commitsigner" ]; then
+          	echo "commit author does not match signed-off-by trailer"
+          	exit 1
+          fi
       - name: Install Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
The GitHub DCO app does not enforce that the author matches the
Signed-off-by trailer. This basic requirement of DCO is enforced by
Gerrit, so if this condition is not satisfied then an approved PR can
still fail at the stage we mail the imported CL to Gerrit (Gerrit
refuses the mail).

For now, manually enforce that the commit author and signed-off-by are
identifical. See code comments for a link to the issue tracking the fix
in the GitHub DCO app.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I16a673c62d9ace7c6cb5f81bc454a36b5da06e2a
