### PR TITLE
Added the sidenote shortcode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,6 +25,9 @@ ij_any_class_brace_style = next_line
 ij_any_method_brace_style = end_of_line
 ij_typescript_use_double_quotes = false
 
+[*.scss]
+quote_type = single
+
 [*.md]
 max_line_length = off
 

--- a/assets/scss/base/base.scss
+++ b/assets/scss/base/base.scss
@@ -54,7 +54,7 @@ h6 {
     @include style-heading;
 
     color: var(--heading-color);
-    margin: 1em 0 .5em;
+    margin: 1rem 0 .5rem;
 }
 
 h1 {

--- a/assets/scss/components/sidenote.scss
+++ b/assets/scss/components/sidenote.scss
@@ -1,0 +1,61 @@
+@import '../config/colors';
+@import '../config/typography';
+@import '../mixins/typography';
+
+.sidenote {
+    --sidenote-height: 30px;
+
+    $self: &;
+
+    @include style-text-small;
+
+    background-color: $c-yellow;
+    border-radius: 20px;
+    display: block;
+    font-weight: $weight-medium;
+    height: var(--sidenote-height);
+    line-height: var(--sidenote-height);
+    margin: 0 0 .5em;
+    max-width: 100%;
+    overflow: hidden;
+    padding: 0 1rem;
+    position: relative;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: fit-content;
+
+    h1 + & {
+        margin-top: -.5em;
+    }
+
+    @include screen($screen-simple) {
+        clear: right;
+        float: right;
+        margin: calc(-1 * var(--sidenote-height)) 0 0;
+        max-width: 250px;
+
+        h1 + & {
+            margin-top: calc((var(--sidenote-height) + 1rem) * -1);
+        }
+
+        h2 + & {
+            margin-top: calc((var(--sidenote-height) + .7rem) * -1);
+        }
+
+        h3 + &,
+        h4 + &,
+        h5 + &,
+        h6 + & {
+            margin-top: calc((var(--sidenote-height) + .25rem) * -1);
+        }
+
+        p + & {
+            margin: 0;
+        }
+
+        // If is first in article__content: make sure it floats next to article heading
+        .article__content > &:first-child {
+            margin-top: calc((var(--sidenote-height) + 1rem) * -1);
+        }
+    }
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -38,6 +38,7 @@
 @import 'components/search';
 @import 'components/searchbar';
 @import 'components/separator';
+@import 'components/sidenote';
 @import 'components/spinner';
 @import 'components/table';
 @import 'components/teaser';

--- a/content/en/examples/_index.html
+++ b/content/en/examples/_index.html
@@ -69,7 +69,7 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
-                            <a class="nav__link" href="#" disabled>
+                            <a class="nav__link" href="/examples/shortcodes/sidenote/">
                                 <span class="nav__text">Sidenote</span>
                             </a>
                         </li>

--- a/content/en/examples/shortcodes/sidenote/index.md
+++ b/content/en/examples/shortcodes/sidenote/index.md
@@ -1,0 +1,70 @@
+---
+title: Sidenote
+weight: 25
+---
+
+{{< sidenote text="Only in CUE v04.3" >}}
+
+This is a shortcode that can be used to create a sidenote (ie. a 'pill' on the side of the content).
+
+This way content-writers can mark headers with an additional note.
+
+Add the sidenote below the header, not inside, to not make it part of the heading text.
+
+## Examples
+
+```
+# h1 title
+{{</* sidenote text="Only in CUE v04.3" */>}}
+
+## h2 title
+{{</* sidenote text="Only in CUE v04.3" */>}}
+
+### h3 title
+{{</* sidenote text="Only in CUE v04.3" */>}}
+
+#### h4 title
+{{</* sidenote text="Only in CUE v04.3" */>}}
+
+##### h5 title
+{{</* sidenote text="Only in CUE v04.3" */>}}
+
+###### h6 title
+{{</* sidenote text="Only in CUE v04.3" */>}}
+
+```
+
+# h1 title
+{{< sidenote text="Only in CUE v04.3" >}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Convallis aenean et tortor at risus viverra adipiscing at. Vulputate eu scelerisque felis imperdiet proin fermentum leo.
+
+## h2 g  title
+{{< sidenote text="Only in CUE v04.3" >}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Convallis aenean et tortor at risus viverra adipiscing at. Vulputate eu scelerisque felis imperdiet proin fermentum leo.
+
+### h3 g title
+{{< sidenote text="Only in CUE v04.3" >}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Convallis aenean et tortor at risus viverra adipiscing at. Vulputate eu scelerisque felis imperdiet proin fermentum leo.
+
+#### h4 title
+{{< sidenote text="Long text will be cut off when it doesn't fit" >}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Convallis aenean et tortor at risus viverra adipiscing at. Vulputate eu scelerisque felis imperdiet proin fermentum leo.
+
+##### h5 title
+{{< sidenote text="Only in CUE v04.3" >}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Convallis aenean et tortor at risus viverra adipiscing at. Vulputate eu scelerisque felis imperdiet proin fermentum leo.
+
+###### h6 title
+{{< sidenote text="Only in CUE v04.3" >}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Convallis aenean et tortor at risus viverra adipiscing at. Vulputate eu scelerisque felis imperdiet proin fermentum leo.
+
+{{< sidenote text="Only in CUE v04.3" >}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Convallis aenean et tortor at risus viverra adipiscing at. Vulputate eu scelerisque felis imperdiet proin fermentum leo.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Convallis aenean et tortor at risus viverra adipiscing at. Vulputate eu scelerisque felis imperdiet proin fermentum leo.

--- a/layouts/shortcodes/sidenote.html
+++ b/layouts/shortcodes/sidenote.html
@@ -1,0 +1,1 @@
+<span class="sidenote">{{- .Get "text" -}}</span>


### PR DESCRIPTION
Includes:
- Created the sidenote shortcode
- Styling of the sidenote in all content cases
- Change margin of h's to rem instead of em to ensure margin's don't depend on font-size and are same everywhere
- Added an example page for the sidenote shortcode: /examples/shortcodes/sidenote/

Also edited:
- editorconfig; 'quote_type = single' for scss files so the single quotes do not switch to double quotes when the file is saved

Closes #296

Signed-off-by: Anne van Gorkom <anne.van.gorkom@usmedia.nl>
Change-Id: Ib1ecb668b7200dfec0aafa0fe79bcbea88ac8659
