### PR TITLE
/examples: consistently name Info Block component

### DIFF
--- a/hugo/content/en/examples/_index.html
+++ b/hugo/content/en/examples/_index.html
@@ -65,7 +65,7 @@ description: "View examples on how to use certain possible elements of the theme
                         </li>
                         <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/info/">
-                                <span class="nav__text">Info / Warning / Caution</span>
+                                <span class="nav__text">Info Block</span>
                             </a>
                         </li>
                         <li class="nav__item">


### PR DESCRIPTION
This brings the name of the Info Block example in line with the title
of the page it links to, which is the correct agreed name of this
component.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I5a724f28fc265ddbcfb1352b4da5b72187793bf5
