### PR TITLE
all: change footer links in main menu

### DIFF
--- a/hugo/config/_default/menus/menus.en.toml
+++ b/hugo/config/_default/menus/menus.en.toml
@@ -77,20 +77,19 @@
     weight = 401
 [[footer]]
     parent = "column2"
-    name = "Recorded talks"
+    name = "The CUE Community"
     url = "#"
     weight = 420
 [[footer]]
     parent = "column2"
-    name = "Meetups"
-    url = "#"
+    name = "Contributing"
+    url = "/community/contribution-guidelines"
     weight = 421
 [[footer]]
     parent = "column2"
-    name = "Conferences"
-    url = "#"
+    name = "Code of Conduct"
+    url = "/community/conduct"
     weight = 422
-
 [[footer]]
     identifier = "column3"
     name = "About"
@@ -106,12 +105,6 @@
     name = "Blog"
     url = "#"
     weight = 431
-[[footer]]
-    parent = "column3"
-    name = "About CUE"
-    url = "#"
-    weight = 432
-
 [[footer]]
     identifier = "column4"
     name = "Connect"


### PR DESCRIPTION
* closes cue-lang/docs-and-content#46
* updates footer links that belong to the main layout for alpha
* the referenced directories and files will be added in separate CLs.

Signed-off-by: Carmen Andoh <carmen.andoh@gmail.com>
Change-Id: Iaaac6eca6db9997cbbdc3fee5e710b320a1f3d79
