### PR TITLE
all: update footer links and refs in main menu

### DIFF
--- a/hugo/config/_default/menus/menus.en.toml
+++ b/hugo/config/_default/menus/menus.en.toml
@@ -77,20 +77,19 @@
     weight = 401
 [[footer]]
     parent = "column2"
-    name = "Recorded talks"
-    url = "#"
+    name = "The CUE Community"
+    url = "/community"
     weight = 420
 [[footer]]
     parent = "column2"
-    name = "Meetups"
-    url = "#"
+    name = "Contributing"
+    url = "/community/contribution-guidelines"
     weight = 421
 [[footer]]
     parent = "column2"
-    name = "Conferences"
-    url = "#"
+    name = "Code of Conduct"
+    url = "/community/conduct"
     weight = 422
-
 [[footer]]
     identifier = "column3"
     name = "About"
@@ -103,15 +102,9 @@
     weight = 430
 [[footer]]
     parent = "column3"
-    name = "Blog"
+    name = "/blog"
     url = "#"
     weight = 431
-[[footer]]
-    parent = "column3"
-    name = "About CUE"
-    url = "#"
-    weight = 432
-
 [[footer]]
     identifier = "column4"
     name = "Connect"


### PR DESCRIPTION
* closes cue-lang/docs-and-content#46
* updates all footer links that belong to the main layout for alpha
* the referenced directories and files will be added in separate CLs.

Signed-off-by: Carmen Andoh <carmen.andoh@gmail.com>
Change-Id: Iaaac6eca6db9997cbbdc3fee5e710b320a1f3d79
