### PR TITLE
/docs/install: create placeholder page

### DIFF
--- a/hugo/config/_default/menus/menus.en.toml
+++ b/hugo/config/_default/menus/menus.en.toml
@@ -44,7 +44,7 @@
 [[cta]]
     identifier = "cta"
     name = "Download"
-    url = "/docs/download/"
+    url = "/download/"
     post = "download"
     weight = 300
 

--- a/hugo/content/en/docs/install/index.md
+++ b/hugo/content/en/docs/install/index.md
@@ -1,0 +1,5 @@
+---
+title: Install
+weight: 10
+draft: false
+---

--- a/internal/ci/netlify/netlify.cue
+++ b/internal/ci/netlify/netlify.cue
@@ -70,6 +70,9 @@ config: #config & {
 		from: "/issue/*"
 		to:   "https://github.com/cue-lang/cue/issues/:splat"
 	}, {
+		from: "/download"
+		to:   "/docs/install"
+	}, {
 		from: "/issues/*"
 		to:   "https://github.com/cue-lang/cue/issues/:splat"
 	}, {

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,6 +27,12 @@ command = "bash build.bash -b $DEPLOY_PRIME_URL"
   force = true
 
 [[redirects]]
+  from = "/download"
+  to = "/docs/install"
+  status = 302
+  force = true
+
+[[redirects]]
   from = "/issues/*"
   to = "https://github.com/cue-lang/cue/issues/:splat"
   status = 302


### PR DESCRIPTION
Also add a redirect from /download to /docs/install for now. Use Netlify
redirects per our existing setup.

Using Netlify redirects has the slightly annoying side effect of us not
being able to see/test the redirect (alias in Hugo's terms) locally. We
can revisit whether it makes more sense to use Hugo aliases later.

Also update the header link to be /download.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I4d5bf758ff97ff9db06a905a902de53aa5261e64
