### PR TITLE
/docs/howto: skeleton files for how-to guides

### DIFF
--- a/hugo/content/en/docs/_index.html
+++ b/hugo/content/en/docs/_index.html
@@ -51,32 +51,12 @@ cascade:
                 </div>
 
                 <div class="index__nav nav nav--index">
-                    <p class="nav__title">Effective CUE</p>
+                    <p class="nav__title">How-to Guides</p>
 
                     <ul class="nav__list">
                         <li class="nav__item">
-                            <a class="nav__link" href="#">
-                                <span class="nav__text">How to organize files</span>
-                            </a>
-                        </li>
-                        <li class="nav__item">
-                            <a class="nav__link" href="#">
-                                <span class="nav__text">Style guide</span>
-                            </a>
-                        </li>
-                        <li class="nav__item">
-                            <a class="nav__link" href="#">
-                                <span class="nav__text">Patterns</span>
-                            </a>
-                        </li>
-                        <li class="nav__item">
-                            <a class="nav__link" href="#" disabled>
-                                <span class="nav__text">Conventions (Coming soon)</span>
-                            </a>
-                        </li>
-                        <li class="nav__item">
-                            <a class="nav__link" href="#" disabled>
-                                <span class="nav__text">Advanced topics (Coming soon)</span>
+                            <a class="nav__link" href="/docs/howto">
+                                <span class="nav__text">How-To Guides</span>
                             </a>
                         </li>
                     </ul>

--- a/hugo/content/en/docs/howto/_index.md
+++ b/hugo/content/en/docs/howto/_index.md
@@ -1,0 +1,5 @@
+---
+title: How-to Guides
+weight: 10
+draft: false
+---

--- a/hugo/content/en/docs/howto/constrain-list-ints-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/constrain-list-ints-no-duplicates/index.md
@@ -1,0 +1,5 @@
+---
+title: How to constrain a list of integers to have no duplicates
+weight: 
+draft: false
+---

--- a/hugo/content/en/docs/howto/constrain-list-strings-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/constrain-list-strings-no-duplicates/index.md
@@ -1,0 +1,5 @@
+---
+title: How to constrain a list of strings with no duplicates
+weight: 
+draft: false
+---

--- a/hugo/content/en/docs/howto/constrain-list-structs-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/constrain-list-structs-no-duplicates/index.md
@@ -1,0 +1,5 @@
+---
+title: How to constrain a list of structs with no duplicates
+weight:
+draft: false
+---

--- a/hugo/content/en/docs/howto/constrain-max-items-list/index.md
+++ b/hugo/content/en/docs/howto/constrain-max-items-list/index.md
@@ -1,0 +1,5 @@
+---
+title: How to constrain the maximum items in a list
+weight:
+draft: false
+---

--- a/hugo/content/en/docs/howto/constrain-min-items-list/index.md
+++ b/hugo/content/en/docs/howto/constrain-min-items-list/index.md
@@ -1,0 +1,5 @@
+---
+title: How to constrain the minimum items in a list
+weight:
+draft: false
+---

--- a/hugo/content/en/docs/howto/encode-data-json-string-within-cue/index.md
+++ b/hugo/content/en/docs/howto/encode-data-json-string-within-cue/index.md
@@ -1,0 +1,5 @@
+---
+title: How to encode data as a JSON string within a larger CUE value
+weight:
+draft: false
+---

--- a/hugo/content/en/docs/howto/use-cue-with-github-actions/index.md
+++ b/hugo/content/en/docs/howto/use-cue-with-github-actions/index.md
@@ -1,0 +1,5 @@
+---
+title: How to use CUE with GitHub Actions
+weight:
+draft: false
+---

--- a/hugo/content/en/docs/howto/validate-yaml-using-cue/index.md
+++ b/hugo/content/en/docs/howto/validate-yaml-using-cue/index.md
@@ -1,0 +1,5 @@
+---
+title: How to validate YAML using CUE
+weight: 
+draft: false
+---


### PR DESCRIPTION
* also adds a skeleton How-to Guides section in /docs/_index.html

Signed-off-by: Carmen Andoh <carmen.andoh@gmail.com>
Change-Id: I0187681daeff2a4a70f7a506919dabbd67d94f19
