### PR TITLE
genContent: only create index file if it doesn't exist

### DIFF
--- a/internal/_scripts/genContent
+++ b/internal/_scripts/genContent
@@ -43,7 +43,9 @@ do
 		dir="$type/$type-$i"
 		file="$dir/index.md"
 		mkdir -p $dir
-		cat <<EOD > $type/_index.md
+		if [ ! -f $type/_index.md ]
+		then
+			cat <<EOD > $type/_index.md
 ---
 title: $j
 weight: 1
@@ -55,7 +57,7 @@ draft: false
 This is some dummy content for $j.
 
 EOD
-
+		fi
 
 		cat <<EOD > $file
 ---


### PR DESCRIPTION
This makes the generated content play more nicely with real
content/files that already exist

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ie8a72f07e7bcca8e6d20bf6fa6b4988821f4181b
