### PR TITLE
/community: adds files, section headers, conduct

### DIFF
--- a/hugo/content/en/community/_index.html
+++ b/hugo/content/en/community/_index.html
@@ -45,3 +45,96 @@ description = "CUE is an open source project that anyone in the community can us
         </div>
     </div>
 </section>
+<div class="section__body">
+    <div class="section__content">
+        <nav class="index">
+            <div class="index__nav nav nav--index">
+                <p class="nav__title">Contributing to CUE</p>
+
+                <ul class="nav__list">
+                    <li class="nav__item">
+                        <a class="nav__link" href=/community/contribution-guidelines>
+                            <span class="nav__text">Contribution Guidelines</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </nav>
+    </div>
+</div>
+</section>
+    <div class="section__body">
+        <div class="section__content">
+            <nav class="index">
+                <div class="index__nav nav nav--index">
+                    <p class="nav__title">Code of Conduct</p>
+
+                    <ul class="nav__list">
+                        <li class="nav__item">
+                            <a class="nav__link" href=/community/conduct>
+                                <span class="nav__text">CUE Code of Conduct</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </nav>
+        </div>
+    </div>
+</section>
+    <div class="section__body">
+        <div class="section__content">
+            <nav class="index">
+                <div class="index__nav nav nav--index">
+                    <p class="nav__title">Community Calls</p>
+
+                    <ul class="nav__list">
+                        <li class="nav__item">
+                            <a class="nav__link" href="https://youtu.be/Fukkq9h62xg">
+                                <span class="nav__text">2023-01-31</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
+                            <a class="nav__link" href="https://www.youtube.com/watch?v=Vqe7X_LXIuA">
+                                <span class="nav__text">2022-11-29</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
+                            <a class="nav__link" href="https://www.youtube.com/watch?v=jMfc-szTLtA">
+                                <span class="nav__text">2022-10-25</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
+                            <a class="nav__link" href="https://youtu.be/Y3NXfX_o3a8">
+                                <span class="nav__text">2022-10-04</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </nav>
+        </div>
+    </div>
+</section>
+</section>
+<div class="section__body">
+    <div class="section__content">
+        <nav class="index">
+            <div class="index__nav nav nav--index">
+                <p class="nav__title">Docs and Content Calls</p>
+
+                <ul class="nav__list">
+                    <li class="nav__item">
+                        <a class="nav__link" href="https://www.youtube.com/watch?v=SDx1GrDp8TA">
+                            <span class="nav__text">2022-11-08</span>
+                        </a>
+                    </li>
+                    <li class="nav__item">
+                        <a class="nav__link" href="https://www.youtube.com/watch?v=tuidWYIpD7w">
+                            <span class="nav__text">2022-10-11</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </nav>
+    </div>
+</div>
+</section>

--- a/hugo/content/en/community/_index.md
+++ b/hugo/content/en/community/_index.md
@@ -1,0 +1,6 @@
+---
+title: Community
+description: All the community information for CUE Project   
+weight: 100
+draft: false
+---

--- a/hugo/content/en/community/conduct/index.md
+++ b/hugo/content/en/community/conduct/index.md
@@ -1,0 +1,100 @@
+---
+title: "Code of Conduct"
+weight: 810
+draft: false
+---
+
+## About
+Online communities include people from many different backgrounds. The CUE contributors are committed to providing a friendly, safe and welcoming environment for all, regardless of gender identity and expression, sexual orientation, disabilities, neurodiversity, physical appearance, body size, ethnicity, nationality, race, age, religion, or similar personal characteristics.
+
+The first goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about CUE effectively, productively, and respectfully.
+
+The second goal is to provide a mechanism for resolving conflicts in the community when they arise.
+
+The third goal of the Code of Conduct is to make our community welcoming to people from different backgrounds. Diversity is critical to the project; for CUE to be successful, it needs contributors and users from all backgrounds. (We take inspiration here from [Go, Open Source, Community](https://blog.golang.org/open-source).)
+
+We believe that healthy debate and disagreement are essential to a healthy project and community. However, it is never ok to be disrespectful. We value diverse opinions, but we value respectful behavior more.
+
+## CUE Values
+
+These are the values to which people in the CUE community should aspire.
+
+*   Be friendly and welcoming.
+*   Be patient.
+    *   Remember that people have varying communication styles and that not everyone is using their native language. (Meaning and tone can be lost in translation.)
+*   Be thoughtful.
+    *   Productive communication requires effort. Think about how your words will be interpreted.
+    *   Remember that sometimes it is best to refrain entirely from commenting.
+*   Be respectful.
+    *   In particular, respect differences of opinion.
+*   Be charitable.
+    *   Interpret the arguments of others in good faith, do not seek to disagree.
+    *   When we do disagree, try to understand why.
+*   Avoid destructive behavior.
+    *   Derailing: stay on topic; if you want to talk about something else, start a new conversation.
+    *   Unconstructive criticism: don't merely decry the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
+    *   Snarking (pithy, unproductive, sniping comments)
+    *   Discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
+    *   Microaggressions: brief and commonplace verbal, behavioral and environmental indignities that communicate hostile, derogatory or negative slights and insults to a person or group.
+*   Be responsible.
+    *  What you say and do matters. Take responsibility for your words and actions, including their consequences, whether intended or otherwise. 
+    
+People are complicated. You should expect to be misunderstood and to misunderstand others; when this inevitably occurs, resist the urge to be defensive or assign blame. Try not to take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do not rise to it. It is the responsibility of _all parties_ to de-escalate conflict when it arises.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+*   The use of sexualized language or imagery and unwelcome sexual attention or advances
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others’ private information, such as a physical or electronic address, without explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when the Project Stewards have a reasonable belief that an individual’s behavior may have a negative impact on the project or its community.
+
+### Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement often yield positive results. However, it is never okay to be disrespectful or to engage in behavior that violates the project’s code of conduct.
+
+If you see someone violating the code of conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
+
+Reports should be directed the CUE Project Conduct Stewards, at _conduct@cuelang.org_.
+
+We will investigate every complaint, but you may not receive a direct response. We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. The identity of the reporter will be omitted from the details of the report supplied to the accused. In potentially harmful situations, such as ongoing harassment or threats to anyone’s safety, we may take action without notice.
+
+### Attribution[](#attribution)
+
+This Code of Conduct is adapted from the [Go Community Code of Conduct](https://go.dev/conduct), which itself is adapted from the Contributor Covenant, version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
+
+Summary[](#summary)
+-------------------
+
+*   Treat everyone with respect and kindness.
+*   Be thoughtful in how you communicate.
+*   Don’t be destructive or inflammatory.
+*   If you encounter an issue, please mail [conduct@cuelang.org](mailto:conduct@cuelang.org).

--- a/hugo/content/en/community/contribution-guidelines/index.md
+++ b/hugo/content/en/community/contribution-guidelines/index.md
@@ -1,0 +1,5 @@
+---
+title: Contribution Guidelines for the CUE Open Source Project
+weight: 10
+draft: false
+---


### PR DESCRIPTION
Initial commit for the /community directory. This adds
* subsections in the /community landing page for
/contribution-guidelines and /conduct, as
well as links to past community calls recordings.
* the CUE Code of Conduct, taken from the
current CoC.

Signed-off-by: Carmen Andoh <carmen.andoh@gmail.com>
Change-Id: I6237cc7419e97e92de4a669079c1e78109a5eee1
