### PR TITLE
Hugo: Add option to set toc-root on a section

### DIFF
--- a/hugo/layouts/partials/paging/tree.html
+++ b/hugo/layouts/partials/paging/tree.html
@@ -1,6 +1,25 @@
 <nav class="tree">
-    {{ $navRoot := .FirstSection -}}
     {{ $current := . -}}
+    {{ $navRoot := "" -}}
+
+    {{- if ( or (eq $current .FirstSection) (eq $current.Params.toc_root true)) -}}
+        {{ $navRoot = $current }}
+    {{- end -}}
+
+    {{- if (eq $navRoot "") -}}
+        {{ $parent := .Parent -}}
+        {{- if (eq $parent.Params.toc_root true) -}}
+            {{ $navRoot = $parent -}}
+        {{- else -}}
+            {{ $parent = $parent.Parent -}}
+            {{- if (eq $parent.Params.toc_root true) -}}
+                {{ $navRoot = $parent -}}
+            {{- else -}}
+                {{ $navRoot = .FirstSection -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+
     {{ $depth := 1 -}}
     {{ $maxDepth := 3 -}}
 


### PR DESCRIPTION
- Setting params toc_root to true will start the tree table of contents
  at that section.
- All child sections will use a parent with toc_root set to true as the
  starting point of the index.
- If current page is not toc_root or doesn't have a parent with toc_root
  set to true it will fall back on .FirstSection

For https://linear.app/usmedia/issue/CUE-133

See the next CL in the chain for this being turned on for the language
guide.

Closes #310 as merged.

Signed-off-by: Jorinde Reijnierse <jorinde.reijnierse@usmedia.nl>
Change-Id: Ia639e7c04e7e8c5f6ac1aec78fdebc8376067a38
