### PR TITLE
Add table shortcode

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -14,8 +14,8 @@
     --text-link-color: #{ $c-blue };
     --caption-color: #{ transparentize($c-grey--darkest, .3) };
     --list-color: #{ $c-blue };
-    --table-border-color: #{ $c-grey--light };
-    --table-header-border-color: #{ $c-grey };
+    --table-border-color: #{ transparentize($c-blue--light, .85) };
+    --table-header-border-color: #{ transparentize($c-blue--light, .85) };
     --pre-color: #{ $c-grey--darkest };
     --pre-background-color: #{ $c-blue--lighter };
     --pre-border-color: #{ $c-blue--lighter };
@@ -217,17 +217,20 @@ dd {
 
 table {
     border-collapse: collapse;
-    border-radius: 4px;
+    border-radius: 0;
     margin: 0 0 1rem;
     overflow: hidden;
     text-align: left;
     width: 100%;
 }
 
+thead {
+    background-color: $c-yellow;
+}
+
 th,
 td {
-    border-bottom: 1px solid var(--table-border-color);
-    padding: .5em $p-gutter;
+    padding: $p-gutter;
     vertical-align: top;
 
     p:last-of-type {
@@ -243,10 +246,10 @@ th {
 }
 
 tr {
-    &:last-child {
-        td {
-            border-bottom: 0;
-        }
+    &:nth-child(even) {
+        background-color: $c-blue--lightest;
+        border-bottom: 1px solid var(--table-border-color);
+        border-top: 1px solid var(--table-border-color);
     }
 }
 

--- a/hugo/assets/scss/config/colors.scss
+++ b/hugo/assets/scss/config/colors.scss
@@ -1,3 +1,4 @@
+$c-blue--lightest:      #f8f9fd;
 $c-blue--lighter:       #f0f2fb;
 $c-blue--light:         #1b3987;
 $c-blue:                #232a68;

--- a/hugo/content/en/examples/_index.html
+++ b/hugo/content/en/examples/_index.html
@@ -96,7 +96,7 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
-                            <a class="nav__link" href="#" disabled>
+                            <a class="nav__link" href="/examples/shortcodes/table/">
                                 <span class="nav__text">Table</span>
                             </a>
                         </li>

--- a/hugo/content/en/examples/shortcodes/sidenote/index.md
+++ b/hugo/content/en/examples/shortcodes/sidenote/index.md
@@ -1,6 +1,6 @@
 ---
 title: Sidenote
-weight: 25
+weight: 27
 ---
 
 {{< sidenote text="Only in CUE v04.3" >}}

--- a/hugo/content/en/examples/shortcodes/spinner/index.md
+++ b/hugo/content/en/examples/shortcodes/spinner/index.md
@@ -1,6 +1,6 @@
 ---
 title: Spinner
-weight: 26
+weight: 28
 ---
 
 The spinner shortcode is used to show a simple spinner. Not really needed in content - but it can be used in certain pieces of content which are replaced with Javascript.

--- a/hugo/content/en/examples/shortcodes/table/index.md
+++ b/hugo/content/en/examples/shortcodes/table/index.md
@@ -1,0 +1,53 @@
+---
+title: Table
+weight: 29
+---
+
+## Basic table
+
+```
+{{</* table */>}}
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+{{</* /table */>}}
+```
+
+```
+{{</* table */>}}
+| Syntax | Description |
+| --- | ----------- |
+| Header | Title |
+| Paragraph | Text |
+{{</* /table */>}}
+```
+
+Both versions result in the following table
+
+{{< table >}}
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+{{< /table >}}
+
+## Alignment in table
+
+It is also possible to set the alignment of each column
+
+```
+{{</* table */>}}
+| Syntax      | Description | Test Text     |
+| :---        |    :----:   |          ---: |
+| Header      | Title       | Here's this   |
+| Paragraph   | Text        | And more      |
+{{</* /table */>}}
+```
+
+{{< table >}}
+| Syntax      | Description | Test Text     |
+| :---        |    :----:   |          ---: |
+| Header      | Title       | Here's this   |
+| Paragraph   | Text        | And more      |
+{{< /table >}}

--- a/hugo/content/en/examples/shortcodes/todo/index.md
+++ b/hugo/content/en/examples/shortcodes/todo/index.md
@@ -1,6 +1,6 @@
 ---
 title: Todo
-weight: 28
+weight: 31
 ---
 
 The todo shortcode is a simple shortcode used to show a section / block which is still under construction.

--- a/hugo/content/en/examples/shortcodes/youtube/index.md
+++ b/hugo/content/en/examples/shortcodes/youtube/index.md
@@ -1,6 +1,6 @@
 ---
 title: YouTube
-weight: 29
+weight: 32
 ---
 
 When using the youtube shortcode, you will need the Video ID associated YouTube video.


### PR DESCRIPTION
This includes:
- Fix weights of example pages
- Added link to table shortcode example page
- Created table shortcode example page
- Added a lighter color blue for tables and future components
- Added table styling
- Add table shortcode example page

For https://linear.app/usmedia/issue/CUE-123.

Closes #307 as merged.

Signed-off-by: Anne van Gorkom <anne.van.gorkom@usmedia.nl>
Change-Id: I84746aa138a6bb207b96f2d1168bd6d8a079943f
