### PR TITLE
Hugo: Code block refinements & bugs fixes

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -351,7 +351,7 @@ pre {
     border-radius: 5px;
     color: var(--pre-color);
     height: 100%;
-    margin-bottom: 1rem;
+    margin: 0 0 1rem;
     max-width: 100%;
     overflow: auto;
     padding: 1rem 1.25rem;

--- a/hugo/assets/scss/components/highlight-title.scss
+++ b/hugo/assets/scss/components/highlight-title.scss
@@ -1,0 +1,20 @@
+@import '../config/colors';
+@import '../config/typography';
+
+.highlight-title {
+    background-color: var(--pre-background-color, $c-blue--lighter);
+    border-radius: 5px 5px 0 0;
+    color: $c-blue;
+    font-weight: $weight-medium;
+    padding: 1rem 1.25rem 0 1.25rem;
+
+    + .highlight {
+        pre {
+            border-radius: 0 0 5px 5px;
+        }
+    }
+
+    & + pre {
+        border-radius: 0 0 5px 5px;
+    }
+}

--- a/hugo/assets/scss/components/highlight.scss
+++ b/hugo/assets/scss/components/highlight.scss
@@ -1,28 +1,15 @@
-@import '../config/typography';
+@import '../config/colors';
+@import '../config/sizes';
 @import '../mixins/screen';
 
 .highlight {
-    $self: &;
-
     height: 100%;
+    margin-bottom: 1rem;
     position: relative;
 
-    &__title {
-        background-color: var(--pre-background-color);
-        border-radius: 5px 5px 0 0;
-        font-weight: $weight-medium;
-        padding: 1rem 1.25rem 0 1.25rem;
-
-        + #{ $self } {
-            pre {
-                border-radius: 0 0 5px 5px;
-                padding-top: 0;
-            }
-        }
-    }
-
     pre {
-        background-color: var(--pre-background-color) !important; // needs !important otherwise Hugo overwrites the styling
+        // overwriting background-color needs !important otherwise Hugo inline styles overwrite the styling
+        background-color: var(--pre-background-color, $c-blue--lighter) !important;
         margin: 0;
     }
 

--- a/hugo/assets/scss/main.scss
+++ b/hugo/assets/scss/main.scss
@@ -23,6 +23,7 @@
 @import 'components/footer';
 @import 'components/header';
 @import 'components/highlight';
+@import 'components/highlight-title';
 @import 'components/index';
 @import 'components/lastmod';
 @import 'components/link';

--- a/hugo/config/_default/config.toml
+++ b/hugo/config/_default/config.toml
@@ -15,11 +15,9 @@ disableAliases = true # We use Netlify server-side redirects instead of generate
 # theme = ["docsy"]
 
 # Highlighting
-pygmentsCodeFences = true
-pygmentsUseClasses = false
-pygmentsUseClassic = false # Use the new Chroma Go highlighter in Hugo.
-# pygmentsOptions = "linenos=table"
-pygmentsStyle = "tango" # See https://help.farbox.com/pygments.html
+[markup]
+    [markup.highlight]
+        lineNumbersInTable = false
 
 # Image processing
 [imaging]

--- a/hugo/content/en/docs/tour/_index.md
+++ b/hugo/content/en/docs/tour/_index.md
@@ -1,0 +1,12 @@
+---
+title: Tour
+weight: 10
+draft: false
+toc_root: true
+---
+
+Get a quick start of CUE with a Tour of the basics.  
+
+Looking for a deep dive of CUE?
+[The Language Guide]({{< relref "language-guide.md" >}}).
+(_Currently in Alpha_)

--- a/hugo/content/en/docs/tour/constraints/index.md
+++ b/hugo/content/en/docs/tour/constraints/index.md
@@ -1,0 +1,45 @@
+---
+title: Constraints
+weight: 120
+draft: false
+---
+
+Constraints specify what values are allowed.
+To CUE they are just values like anything else,
+but conceptually they can be explained as something in between types and concrete values.
+
+Constraints can also reduce boilerplate.
+If a constraint defines a concrete value, there is no need
+to specify it in values to which this constraint applies.
+
+{{< columns >}}
+
+```{title="check.cue"}"
+schema: {
+    name:  string
+    age:   int
+    human: true // always true
+}
+
+viola: schema
+viola: {
+    name: "Viola"
+    age:  38
+}
+```
+
+{{< columns-separator >}}
+
+```{title="$ cue eval check.cue"}
+schema: {
+    name:  string
+    age:   int
+    human: true
+}
+viola: {
+    name:  "Viola"
+    age:   38
+    human: true
+}
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/definitions/index.md
+++ b/hugo/content/en/docs/tour/definitions/index.md
@@ -1,0 +1,47 @@
+---
+title: Definitions
+weight: 150
+draft: false
+---
+
+In CUE, schemas are typically written as Definitions.
+A definition is a field which identifier starts with
+`#` or `_#`.
+This tells CUE that they are to be used for validation and should
+not be output as data; it is okay for them to remain unspecified.
+
+A definition also tells CUE the full set of allowed fields.
+In other words, definitions define "closed" structs.
+Including a `...` in struct keeps it open.
+
+For more information on CUE Definitions, see [The Language Guide]({{< relref "docs/language-guide/" >}}).
+
+{{< columns >}}
+
+```{title="schema.cue"}
+#Conn: {
+    address:  string
+    port:     int
+    protocol: string
+    // ...    // uncomment this to allow any field
+}
+
+lossy: #Conn & {
+    address:  "1.2.3.4"
+    port:     8888
+    protocol: "udp"
+    // foo: 2 // uncomment this to get an error
+}
+```
+{{< columns-separator >}}
+
+```schema.cue {title="$ cue export schema.cue"}
+{
+    "lossy": {
+        "address": "1.2.3.4",
+        "port": 8888,
+        "protocol": "udp"
+    }
+}
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/duplicate-fields/index.md
+++ b/hugo/content/en/docs/tour/duplicate-fields/index.md
@@ -1,0 +1,40 @@
+---
+title: Duplicate Fields
+weight: 90
+draft: false
+---
+
+CUE allows duplicated field definitions as long as they don't conflict.
+
+For values of basic types this means they must be equal.
+
+For structs, fields are merged and duplicated fields are handled recursively.
+
+For lists, all elements must match accordingly
+<!-- ([we discuss open-ended lists later](/language-guide/data/lists/).) -->
+
+{{< columns >}}
+
+```{title="dup.cue"}
+a: 4
+a: 4
+
+s: { b: 2 }
+s: { c: 2 }
+
+l: [ 1, 2 ]
+l: [ 1, 2 ]
+```
+
+{{< columns-separator >}}
+
+```{title="$ cue eval dup.cue"}
+a: 4
+s: {
+    b: 2
+    c: 2
+}
+l: [1, 2]
+```
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/folding-structs/index.md
+++ b/hugo/content/en/docs/tour/folding-structs/index.md
@@ -1,0 +1,46 @@
+---
+title: Folding of Single-Field Structs
+weight: 240
+draft: false
+---
+
+In JSON, one defines nested values one value at a time.
+Another way to look at this is that a JSON configuration is a set of
+path-value pairs.
+
+In CUE one defines a set of paths of which to apply
+a concrete value or constraint all at once.
+Because of CUE's order independence, values get merged
+
+This example shows some path-value pairs, as well as
+a constraint that is applied to those to validate them.
+<!--
+This also gives a handy shorthand for writing structs with single
+members.
+-->
+
+{{< columns >}}
+```{title="fold.cue"}
+// path-value pairs
+outer: middle1: inner: 3
+outer: middle2: inner: 7
+
+// collection-constraint pair
+outer: [string]: inner: int
+```
+
+{{< columns-separator >}}
+
+```
+{
+    "outer": {
+        "middle1": {
+            "inner": 3
+        },
+        "middle2": {
+            "inner": 7
+        }
+    }
+}
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/json-superset/index.md
+++ b/hugo/content/en/docs/tour/json-superset/index.md
@@ -1,0 +1,54 @@
+---
+title: JSON Superset
+weight: 30
+draft: false
+---
+
+
+CUE is a superset of JSON.
+It adds the following conveniences:
+
+- C-style comments,
+- quotes may be omitted from field names without special characters,
+- commas at the end of fields are optional,
+- comma after last element in list is allowed,
+- outer curly braces are optional.
+
+{{< info >}}
+_CUE borrows a trick from Go to make commas optional._
+{{< /info >}}
+
+JSON objects are called structs in CUE.
+An object member is called a field.
+
+{{< columns >}}
+
+``` {title="json.cue"}
+one: 1
+two: 2
+
+// A field using quotes.
+"two-and-a-half": 2.5
+
+list: [
+	1,
+	2,
+	3,
+]
+```
+{{< columns-separator >}}
+
+```{title="$cue export json.cue"}
+{
+    "list": [
+        1,
+        2,
+        3
+    ],
+    "one": 1,
+    "two": 2,
+    "two-and-a-half": 2.5
+}
+```
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/order-irrelevance/index.md
+++ b/hugo/content/en/docs/tour/order-irrelevance/index.md
@@ -1,0 +1,34 @@
+---
+title: Order is Irrelevant
+weight: 210
+draft: false
+---
+
+CUE's basic operations are defined in a way that the order in which
+you combine two configurations is irrelevant to the outcome.
+
+This is crucial property of CUE
+that makes it easy for humans _and_ machines to reason over values and
+makes advanced tooling and automation possible.
+
+{{< columns >}}
+```{title="order.cue"}
+a: {x: 1, y: int}
+a: {x: int, y: 2}
+
+b: {x: int, y: 2}
+b: {x: 1, y: int}
+```
+{{< columns-separator >}}
+
+```{title="$ cue eval -i order.cue"}
+a: {
+    x: 1
+    y: 2
+}
+b: {
+    x: 1
+    y: 2
+}
+```
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/types-are-values/index.md
+++ b/hugo/content/en/docs/tour/types-are-values/index.md
@@ -1,0 +1,53 @@
+---
+title: Types are Values
+weight: 60
+draft: false
+---
+
+CUE merges the concepts of values and types.
+Below is a demonstration of this concept,
+showing respectively
+some data, a possible schema for this data,
+and something in between: a typical CUE constraint.
+
+{{< columns >}}
+Data
+
+```
+moscow: {
+  name:    "Moscow"
+  pop:     11.92M
+  capital: true
+}
+```
+
+{{< columns-separator >}}
+
+Schema
+
+```
+municipality: {
+  name:    string
+  pop:     int
+  capital: bool
+}
+```
+
+{{< columns-separator >}}
+
+CUE
+
+```
+largeCapital: {
+  name:    string
+  pop:     >5M
+  capital: true
+}
+```
+
+{{< /columns >}}
+
+In general, in CUE one starts with a broad definition of a schema,
+describing all possible instances,
+and then narrows down these definitions for particular use cases
+until a concrete data instance remains.

--- a/hugo/content/en/docs/tour/validation/index.md
+++ b/hugo/content/en/docs/tour/validation/index.md
@@ -1,0 +1,47 @@
+---
+title: Validation
+weight: 180
+draft: false
+---
+
+Constraints can be used to validate values of concrete instances.
+They can be applied to CUE data, or directly to YAML or JSON.
+
+Here we see a constraint where all languages in `data.yaml` must start with
+an uppercase letter, specified in`schema.cue`.
+The constrainst is validated with `cue vet`.
+
+{{< info >}}
+For more information about the `cue` command, see
+[cmd/cue command line](https://cue.googlesource.com/cue/+/refs/tags/v0.2.0/doc/cmd/cue.md) 
+{{< /info >}}
+
+{{< columns >}}
+
+```{title="schema.cue"}
+#Language: {
+	tag:  string
+	name: =~"^\\p{Lu}" // Must start with an uppercase letter.
+}
+languages: [...#Language]
+```
+
+```{title="data.yaml"}
+languages:
+  - tag: en
+    name: English
+  - tag: nl
+    name: dutch
+  - tag: no
+    name: Norwegian
+ ```
+
+{{< columns-separator >}}
+
+```{title="$ cue vet schema.cue data.yaml"}
+languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
+    ./schema.cue:3:8
+    ./data.yaml:5:12
+```
+
+{{< /columns >}}

--- a/hugo/content/en/examples/basic/block/index.md
+++ b/hugo/content/en/examples/basic/block/index.md
@@ -282,7 +282,7 @@ You can even mark/highlight part of the code by adding `hl_lines` with the accor
 
 {{< columns >}}
 ````
-```json {title="JSON", hl_lines=["2-3", 6]}
+```json {title="JSON", hl_lines=["2-3", 6], linenos=true}
 {
     "firstName": "John",
     "lastName": "Smith",
@@ -293,7 +293,7 @@ You can even mark/highlight part of the code by adding `hl_lines` with the accor
 ```
 ````
 {{< columns-separator >}}
-```json {title="JSON", hl_lines=["2-3", 6]}
+```json {title="JSON", hl_lines=["2-3", 6], linenos=true}
 {
     "firstName": "John",
     "lastName": "Smith",

--- a/hugo/layouts/_default/_markup/render-codeblock.html
+++ b/hugo/layouts/_default/_markup/render-codeblock.html
@@ -1,5 +1,5 @@
 {{- with (index .Attributes "title") -}}
-    <div class="highlight__title">
+    <div class="highlight-title">
         {{- . -}}
     </div>
 {{- end -}}


### PR DESCRIPTION
- Make sure both codeblocks with and without language attribute
  are rendered correctly. With language attribute hugo renders the
  highlight shortcode, without it renders a regular pre tag.
- Improve margin of pre tag
- Always keep full padding of pre tag to keep distance to title.
- Make title blue instead of darkgrey to make it stand out more
- Add fallback color for background of highlight because we're leaning
  on a variable outside the current scope which can cause problems
  without a default.
- Make highlight title a separate bem-class instead of a bem element
  inside 'highlight'. This is because the title gets rendered outside the
  highlight block. In case of absent language attribute it won't even
  be rendered with the highlight block but with a regular pre tag.
- Remove old pygments config from toml file. We don't need to set
  pygments to false because the default of hugo is now Chroma.
- Set lineNumbersInTable to false in config to force hugo to render
  using modern css instead of tables.
  Tables give a lot of styling problems within code blocks.
- Change examples lineos=table to lineos=true because we don't want
  to use tables

For: https://linear.app/usmedia/issue/CUE-151

Closes #318

Signed-off-by: Jorinde Reijnierse <jorinde.reijnierse@usmedia.nl>
Change-Id: I8358af12960e5b02286281e1b99fac86eaa13260
