### PR TITLE
Hugo: Code block refinements & bugs fixes

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -351,7 +351,7 @@ pre {
     border-radius: 5px;
     color: var(--pre-color);
     height: 100%;
-    margin-bottom: 1rem;
+    margin: 0 0 1rem;
     max-width: 100%;
     overflow: auto;
     padding: 1rem 1.25rem;

--- a/hugo/assets/scss/components/highlight-title.scss
+++ b/hugo/assets/scss/components/highlight-title.scss
@@ -1,0 +1,20 @@
+@import '../config/colors';
+@import '../config/typography';
+
+.highlight-title {
+    background-color: var(--pre-background-color, $c-blue--lighter);
+    border-radius: 5px 5px 0 0;
+    color: $c-blue;
+    font-weight: $weight-medium;
+    padding: 1rem 1.25rem 0;
+
+    + .highlight {
+        pre {
+            border-radius: 0 0 5px 5px;
+        }
+    }
+
+    & + pre {
+        border-radius: 0 0 5px 5px;
+    }
+}

--- a/hugo/assets/scss/components/highlight.scss
+++ b/hugo/assets/scss/components/highlight.scss
@@ -1,28 +1,15 @@
-@import '../config/typography';
+@import '../config/colors';
+@import '../config/sizes';
 @import '../mixins/screen';
 
 .highlight {
-    $self: &;
-
     height: 100%;
+    margin-bottom: 1rem;
     position: relative;
 
-    &__title {
-        background-color: var(--pre-background-color);
-        border-radius: 5px 5px 0 0;
-        font-weight: $weight-medium;
-        padding: 1rem 1.25rem 0;
-
-        + #{ $self } {
-            pre {
-                border-radius: 0 0 5px 5px;
-                padding-top: 0;
-            }
-        }
-    }
-
     pre {
-        background-color: var(--pre-background-color) !important; // needs !important otherwise Hugo overwrites the styling
+        // overwriting background-color needs !important otherwise Hugo inline styles overwrite the styling
+        background-color: var(--pre-background-color, $c-blue--lighter) !important;
         margin: 0;
     }
 

--- a/hugo/assets/scss/main.scss
+++ b/hugo/assets/scss/main.scss
@@ -23,6 +23,7 @@
 @import 'components/footer';
 @import 'components/header';
 @import 'components/highlight';
+@import 'components/highlight-title';
 @import 'components/index';
 @import 'components/lastmod';
 @import 'components/link';

--- a/hugo/config/_default/config.toml
+++ b/hugo/config/_default/config.toml
@@ -15,11 +15,9 @@ disableAliases = true # We use Netlify server-side redirects instead of generate
 # theme = ["docsy"]
 
 # Highlighting
-pygmentsCodeFences = true
-pygmentsUseClasses = false
-pygmentsUseClassic = false # Use the new Chroma Go highlighter in Hugo.
-# pygmentsOptions = "linenos=table"
-pygmentsStyle = "tango" # See https://help.farbox.com/pygments.html
+[markup]
+    [markup.highlight]
+        lineNumbersInTable = false
 
 # Image processing
 [imaging]

--- a/hugo/content/en/examples/basic/block/index.md
+++ b/hugo/content/en/examples/basic/block/index.md
@@ -282,7 +282,7 @@ You can even mark/highlight part of the code by adding `hl_lines` with the accor
 
 {{< columns >}}
 ````
-```json {title="JSON", hl_lines=["2-3", 6]}
+```json {title="JSON", hl_lines=["2-3", 6], linenos=true}
 {
     "firstName": "John",
     "lastName": "Smith",
@@ -293,7 +293,7 @@ You can even mark/highlight part of the code by adding `hl_lines` with the accor
 ```
 ````
 {{< columns-separator >}}
-```json {title="JSON", hl_lines=["2-3", 6]}
+```json {title="JSON", hl_lines=["2-3", 6], linenos=true}
 {
     "firstName": "John",
     "lastName": "Smith",

--- a/hugo/layouts/_default/_markup/render-codeblock.html
+++ b/hugo/layouts/_default/_markup/render-codeblock.html
@@ -1,5 +1,5 @@
 {{- with (index .Attributes "title") -}}
-    <div class="highlight__title">
+    <div class="highlight-title">
         {{- . -}}
     </div>
 {{- end -}}


### PR DESCRIPTION
- Make sure both codeblocks with and without language attribute
  are rendered correctly. With language attribute hugo renders the
  highlight shortcode, without it renders a regular pre tag.
- Improve margin of pre tag
- Always keep full padding of pre tag to keep distance to title.
- Make title blue instead of darkgrey to make it stand out more
- Add fallback color for background of highlight because we're leaning
  on a variable outside the current scope which can cause problems
  without a default.
- Make highlight title a separate bem-class instead of a bem element
  inside 'highlight'. This is because the title gets rendered outside the
  highlight block. In case of absent language attribute it won't even
  be rendered with the highlight block but with a regular pre tag.
- Remove old pygments config from toml file. We don't need to set
  pygments to false because the default of hugo is now Chroma.
- Set lineNumbersInTable to false in config to force hugo to render
  using modern css instead of tables.
  Tables give a lot of styling problems within code blocks.
- Change examples lineos=table to lineos=true because we don't want
  to use tables

For: https://linear.app/usmedia/issue/CUE-151

Closes #318 as merged.

Signed-off-by: Jorinde Reijnierse <jorinde.reijnierse@usmedia.nl>
Change-Id: I8358af12960e5b02286281e1b99fac86eaa13260
