### PR TITLE
/docs/tour/: add WIP tour based on existing tour

### DIFF
--- a/hugo/content/en/docs/_index.html
+++ b/hugo/content/en/docs/_index.html
@@ -47,8 +47,6 @@ cascade:
                                 <span class="nav__text">Tour</span>
                             </a>
                         </li>
-                    </ul>
-                    <ul class="nav__list">
                         <li class="nav__item">
                             <a class="nav__link" href="/download">
                                 <span class="nav__text">Download and Install CUE </span>

--- a/hugo/content/en/docs/tour/_index.md
+++ b/hugo/content/en/docs/tour/_index.md
@@ -1,0 +1,11 @@
+---
+title: Tour
+weight: 30
+draft: false
+---
+
+Get a quick start of CUE with a Tour of the basics.
+
+Looking for a deep dive of CUE?
+See [The Language Guide]({{< relref "language-guide.md" >}}).
+(_Currently in Alpha_)

--- a/hugo/content/en/docs/tour/constraints/index.md
+++ b/hugo/content/en/docs/tour/constraints/index.md
@@ -1,0 +1,45 @@
+---
+title: Constraints
+weight: 120
+draft: false
+---
+
+Constraints specify what values are allowed.
+To CUE they are just values like anything else,
+but conceptually they can be explained as something in between types and concrete values.
+
+Constraints can also reduce boilerplate.
+If a constraint defines a concrete value, there is no need
+to specify it in values to which this constraint applies.
+
+{{< columns >}}
+
+```{title="check.cue"}"
+schema: {
+    name:  string
+    age:   int
+    human: true // always true
+}
+
+viola: schema
+viola: {
+    name: "Viola"
+    age:  38
+}
+```
+
+{{< columns-separator >}}
+
+```{title="$ cue eval check.cue"}
+schema: {
+    name:  string
+    age:   int
+    human: true
+}
+viola: {
+    name:  "Viola"
+    age:   38
+    human: true
+}
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/definitions/index.md
+++ b/hugo/content/en/docs/tour/definitions/index.md
@@ -1,0 +1,45 @@
+---
+title: Definitions
+weight: 150
+draft: false
+---
+
+In CUE, schemas are typically written as Definitions.
+A definition is a field which identifier starts with
+`#` or `_#`.
+This tells CUE that they are to be used for validation and should
+not be output as data; it is okay for them to remain unspecified.
+
+A definition also tells CUE the full set of allowed fields.
+In other words, definitions define "closed" structs.
+Including a `...` in struct keeps it open.
+
+{{< columns >}}
+
+```{title="schema.cue"}
+#Conn: {
+    address:  string
+    port:     int
+    protocol: string
+    // ...    // uncomment this to allow any field
+}
+
+lossy: #Conn & {
+    address:  "1.2.3.4"
+    port:     8888
+    protocol: "udp"
+    // foo: 2 // uncomment this to get an error
+}
+```
+{{< columns-separator >}}
+
+```schema.cue {title="$ cue export schema.cue"}
+{
+    "lossy": {
+        "address": "1.2.3.4",
+        "port": 8888,
+        "protocol": "udp"
+    }
+}
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/duplicate-fields/index.md
+++ b/hugo/content/en/docs/tour/duplicate-fields/index.md
@@ -1,0 +1,40 @@
+---
+title: Duplicate Fields
+weight: 90
+draft: false
+---
+
+CUE allows duplicated field definitions as long as they don't conflict.
+
+For values of basic types this means they must be equal.
+
+For structs, fields are merged and duplicated fields are handled recursively.
+
+For lists, all elements must match accordingly
+<!-- ([we discuss open-ended lists later](/language-guide/data/lists/).) -->
+
+{{< columns >}}
+
+```{title="dup.cue"}
+a: 4
+a: 4
+
+s: { b: 2 }
+s: { c: 2 }
+
+l: [ 1, 2 ]
+l: [ 1, 2 ]
+```
+
+{{< columns-separator >}}
+
+```{title="$ cue eval dup.cue"}
+a: 4
+s: {
+    b: 2
+    c: 2
+}
+l: [1, 2]
+```
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/folding-structs/index.md
+++ b/hugo/content/en/docs/tour/folding-structs/index.md
@@ -1,0 +1,46 @@
+---
+title: Folding of Single-Field Structs
+weight: 240
+draft: false
+---
+
+In JSON, one defines nested values one value at a time.
+Another way to look at this is that a JSON configuration is a set of
+path-value pairs.
+
+In CUE one defines a set of paths of which to apply
+a concrete value or constraint all at once.
+Because of CUE's order independence, values get merged
+
+This example shows some path-value pairs, as well as
+a constraint that is applied to those to validate them.
+<!--
+This also gives a handy shorthand for writing structs with single
+members.
+-->
+
+{{< columns >}}
+```{title="fold.cue"}
+// path-value pairs
+outer: middle1: inner: 3
+outer: middle2: inner: 7
+
+// collection-constraint pair
+outer: [string]: inner: int
+```
+
+{{< columns-separator >}}
+
+```
+{
+    "outer": {
+        "middle1": {
+            "inner": 3
+        },
+        "middle2": {
+            "inner": 7
+        }
+    }
+}
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/json-superset/index.md
+++ b/hugo/content/en/docs/tour/json-superset/index.md
@@ -1,0 +1,59 @@
+---
+title: JSON Superset
+weight: 30
+draft: false
+---
+
+
+CUE is a superset of JSON.
+It adds the following conveniences:
+
+- C-style comments,
+- quotes may be omitted from field names without special characters,
+- commas at the end of fields are optional,
+- comma after last element in list is allowed,
+- outer curly braces are optional.
+
+<!--
+{{< alert color="info">}}
+CUE borrows a trick from Go to make commas optional:
+the formal grammar still requires commas,
+but the scanner inserts commas according to a small set
+of simple rules.
+{{< /alert >}}
+-->
+
+JSON objects are called structs in CUE.
+An object member is called a field.
+
+{{< columns >}}
+
+``` {title="json.cue"}
+one: 1
+two: 2
+
+// A field using quotes.
+"two-and-a-half": 2.5
+
+list: [
+	1,
+	2,
+	3,
+]
+```
+{{< columns-separator >}}
+
+```{title="$cue export json.cue"}
+{
+    "list": [
+        1,
+        2,
+        3
+    ],
+    "one": 1,
+    "two": 2,
+    "two-and-a-half": 2.5
+}
+```
+
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/order-irrelevance/index.md
+++ b/hugo/content/en/docs/tour/order-irrelevance/index.md
@@ -1,0 +1,34 @@
+---
+title: Order is Irrelevant
+weight: 210
+draft: false
+---
+
+CUE's basic operations are defined in a way that the order in which
+you combine two configurations is irrelevant to the outcome.
+
+This is crucial property of CUE
+that makes it easy for humans _and_ machines to reason over values and
+makes advanced tooling and automation possible.
+
+{{< columns >}}
+```{title="order.cue"}
+a: {x: 1, y: int}
+a: {x: int, y: 2}
+
+b: {x: int, y: 2}
+b: {x: 1, y: int}
+```
+{{< columns-separator >}}
+
+```{title="$ cue eval -i order.cue"}
+a: {
+    x: 1
+    y: 2
+}
+b: {
+    x: 1
+    y: 2
+}
+```
+{{< /columns >}}

--- a/hugo/content/en/docs/tour/types-are-values/index.md
+++ b/hugo/content/en/docs/tour/types-are-values/index.md
@@ -1,0 +1,53 @@
+---
+title: Types are Values
+weight: 60
+draft: false
+---
+
+CUE merges the concepts of values and types.
+Below is a demonstration of this concept,
+showing respectively
+some data, a possible schema for this data,
+and something in between: a typical CUE constraint.
+
+{{< columns >}}
+Data
+
+```
+moscow: {
+  name:    "Moscow"
+  pop:     11.92M
+  capital: true
+}
+```
+
+{{< columns-separator >}}
+
+Schema
+
+```
+municipality: {
+  name:    string
+  pop:     int
+  capital: bool
+}
+```
+
+{{< columns-separator >}}
+
+CUE
+
+```
+largeCapital: {
+  name:    string
+  pop:     >5M
+  capital: true
+}
+```
+
+{{< /columns >}}
+
+In general, in CUE one starts with a broad definition of a schema,
+describing all possible instances,
+and then narrows down these definitions for particular use cases
+until a concrete data instance remains.

--- a/hugo/content/en/docs/tour/validation/index.md
+++ b/hugo/content/en/docs/tour/validation/index.md
@@ -1,0 +1,42 @@
+---
+title: Validation
+weight: 180
+draft: false
+---
+
+Constraints can be used to validate values of concrete instances.
+They can be applied to CUE data, or directly to YAML or JSON.
+
+Here we see a constraint where all languages in `data.yaml` must start with
+an uppercase letter, specified in`schema.cue`.
+The constrainst is validated with `cue vet`.
+
+{{< columns >}}
+
+```{title="schema.cue"}
+#Language: {
+	tag:  string
+	name: =~"^\\p{Lu}" // Must start with an uppercase letter.
+}
+languages: [...#Language]
+```
+
+```{title="data.yaml"}
+languages:
+  - tag: en
+    name: English
+  - tag: nl
+    name: dutch
+  - tag: no
+    name: Norwegian
+ ```
+
+{{< columns-separator >}}
+
+```{title="$ cue vet schema.cue data.yaml"}
+languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
+    ./schema.cue:3:8
+    ./data.yaml:5:12
+```
+
+{{< /columns >}}


### PR DESCRIPTION
This commit takes the Intro section only from
https://cuelang.org/docs/tutorials/tour/
with modifications to render on the new site.
The final tour will very likely be different, as we find the right
quick start content to complement the deeper dive language guide.
This serves as an initial implementation for alpha.

* adds /tour folder with subfolders and /.index.md with plain markdown
and column shortcodes.
* updates the tour link and description to sit under "Getting Started"
in /docs/_index.html

For https://github.com/cue-lang/docs-and-content#55

Signed-off-by: Carmen Andoh <carmen.andoh@gmail.com>
Change-Id: I640dd9253a1031223603339422d60e9d71b92aa8
