### PR TITLE
docs/howto: use code block titles within yaml validation guide

### DIFF
--- a/hugo/content/en/docs/howto/validate-yaml-using-cue/index.md
+++ b/hugo/content/en/docs/howto/validate-yaml-using-cue/index.md
@@ -26,7 +26,7 @@ allows you to run `cue` commands
 
 Create a YAML file called `x.yaml` with the following:
 
-```
+``` {title="x.yaml"}
 people:
   Gopher:
     name: Gopher
@@ -43,7 +43,7 @@ Create a CUE file named `x.cue`
 The following CUE creates a CUE definition that describes the data type
 constraints for every person.
 
-```
+``` {title="x.cue"}
 #Person: {
  name:    string
  age:     int
@@ -65,7 +65,7 @@ _NOTE: `cue vet` is silent when run successfully. Output will only show on error
 
 Add another person to your YAML data.
 
-```
+``` {title="x.yaml"}
 people:
   Gopher:
     name: Gopher
@@ -83,7 +83,7 @@ people:
 
 Validate again with `cue vet`
 
-```
+```console
 $ cue vet x.cue x.yaml
 people.Rob.age: conflicting values 42.2 and int (mismatched types float and int):
     ./x.cue:3:11
@@ -96,7 +96,7 @@ the (type) constraints that you have declared.
 
 Fix up the YAML
 
-```
+``` {title="x.yaml"}
 people:
   Gopher:
     name: Gopher


### PR DESCRIPTION
Per Carmen, a correction to a mistakenly committed /docs/howto/ file
with remnants of a merge conflict. It also fixes fixes misc whitespace,
trailing space, and formatting errors.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ib3be315a148b0d211b484ceab6aacd52ebd33456
