### PR TITLE
Hugo: Table theme options

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -15,6 +15,8 @@
     --text-link-color: #{ $c-blue };
     --caption-color: #{ transparentize($c-grey--darkest, 0.3) };
     --list-color: #{ $c-blue };
+    --table-head-background: #{ $c-blue--lightest };
+    --table-row-background: #{ $c-blue--lightest };
     --table-border-color: #{ transparentize($c-blue--light, 0.85) };
     --table-header-border-color: #{ transparentize($c-blue--light, 0.85) };
     --pre-color: #{ $c-grey--darkest };
@@ -222,12 +224,11 @@ table {
 }
 
 thead {
-    background-color: $c-yellow;
+    background-color: var(--table-head-background);
 }
-
 th,
 td {
-    padding: $p-gutter;
+    padding: 1rem;
     vertical-align: top;
 
     p:last-of-type {
@@ -240,11 +241,12 @@ th {
 
     border-bottom: 1px solid var(--table-header-border-color);
     color: var(--heading-color);
+    padding: $p-gutter;
 }
 
 tr {
     &:nth-child(even) {
-        background-color: $c-blue--lightest;
+        background-color: var(--table-row-background);
         border-bottom: 1px solid var(--table-border-color);
         border-top: 1px solid var(--table-border-color);
     }

--- a/hugo/assets/scss/components/table.scss
+++ b/hugo/assets/scss/components/table.scss
@@ -7,4 +7,8 @@
     table {
         max-width: 100%;
     }
+
+    &--yellow {
+        --table-head-background: #{ $c-yellow };
+    }
 }

--- a/hugo/content/en/examples/shortcodes/table/index.md
+++ b/hugo/content/en/examples/shortcodes/table/index.md
@@ -32,6 +32,20 @@ Both versions result in the following table
 | Paragraph   | Text        |
 {{< /table >}}
 
+## Theme
+The default theme for the table is white/lightblue.
+You can set the theme: this will result in a different table head color.
+
+yellow
+: {{</* table theme="yellow" */>}}
+
+{{< table theme="yellow">}}
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+{{< /table >}}
+
 ## Alignment in table
 
 It is also possible to set the alignment of each column

--- a/hugo/layouts/shortcodes/table.html
+++ b/hugo/layouts/shortcodes/table.html
@@ -1,7 +1,8 @@
-{{ $file := .Get "file" | default "" -}}
-{{ $dataFile := index .Site.Data $file -}}
+{{- $file := .Get "file" | default "" -}}
+{{- $dataFile := index .Site.Data $file -}}
+{{- $theme := .Get "theme" | default "" -}}
 
-<div class="table">
+<div class="table{{ with $theme }} table--{{ . }}{{ end }}">
     {{- if $dataFile -}}
         {{- template "data-table" (dict "file" $dataFile) -}}
     {{- else -}}


### PR DESCRIPTION
- Make table-cell padding a bit less so it's better readable
- Use css variables to set the background of table-cell and table-head
  so they can be overruled
- Make default table theme white/lightblue
- Add option to add theme to a table (for now only yellow)
- Update example page with table-theme example.

For: https://linear.app/usmedia/issue/CUE-170

Closes #326 as merged.

Signed-off-by: Jorinde Reijnierse <jorinde.reijnierse@usmedia.nl>
Change-Id: Ibf0c3fffb049f20687a598c327708fda8b5110de
