### PR TITLE
internal/ci: only compare email address when verifying DCO

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -59,16 +59,19 @@ jobs:
           # generally be the case, and we can always relax this when presented with
           # specific situations where it is is a problem.
 
-          # commit author
-          commitauthor="$(git log -1 --pretty="%an <%ae>")"
+          # commit author email address
+          commitauthor="$(git log -1 --pretty="%ae")"
 
-          # signed-off-by trailer
+          # signed-off-by trailer email address. There is no way to parse just the
+          # email address from the trailer in the same way as git log, so instead
+          # grab the relevant trailer and then take the last whitespace-delimited
+          # part as the "<>" contained email address.
           # Getting the Signed-off-by trailer in this way causes blank
           # lines for some reason. Use awk to remove them.
-          commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | awk NF)"
+          commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | awk NF | awk '{print $NF}' | sed -e 's/[<>]//g')"
 
           if [[ "$commitauthor" != "$commitsigner" ]]; then
-          	echo "commit author does not match signed-off-by trailer"
+          	echo "commit author email address does not match signed-off-by trailer"
           	exit 1
           fi
       - name: Install Node

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -99,16 +99,19 @@ import (
 		# generally be the case, and we can always relax this when presented with
 		# specific situations where it is is a problem.
 
-		# commit author
-		commitauthor="$(git log -1 --pretty="%an <%ae>")"
+		# commit author email address
+		commitauthor="$(git log -1 --pretty="%ae")"
 
-		# signed-off-by trailer
+		# signed-off-by trailer email address. There is no way to parse just the
+		# email address from the trailer in the same way as git log, so instead
+		# grab the relevant trailer and then take the last whitespace-delimited
+		# part as the "<>" contained email address.
 		# Getting the Signed-off-by trailer in this way causes blank
 		# lines for some reason. Use awk to remove them.
-		commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | awk NF)"
+		commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | awk NF | awk '{print $NF}' | sed -e 's/[<>]//g')"
 
 		if [[ "$commitauthor" != "$commitsigner" ]]; then
-			echo "commit author does not match signed-off-by trailer"
+			echo "commit author email address does not match signed-off-by trailer"
 			exit 1
 		fi
 		"""


### PR DESCRIPTION
We currently perform a very naive check that the commit author (name and
email) exactly matches the Signed-off-by trailer. Gerrit, however, only
checks that the email address is the same.

Fix our simple check to only compare email address, which allows for
slight variations in the name in either the commit author and/or the
signed-off-by trailer.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I9a6c17dc14df273fd7eb398ddf39a9ec0a2eed5b
