### PR TITLE
internal/ci: only compare email address when verifying DCO

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -28,9 +28,7 @@ jobs:
           # recently. Increase it to 5 or 10 soon, to also cover CL chains.
           for commit in $(git rev-list --max-count=1 HEAD); do
           	if ! git rev-list --format=%B --max-count=1 $commit | grep -q '^Signed-off-by:'; then
-          		echo -e "
-          Recent commit is lacking Signed-off-by:
-          "
+          		echo -e "\nRecent commit is lacking Signed-off-by:\n"
           		git show --quiet $commit
           		exit 1
           	fi
@@ -59,16 +57,19 @@ jobs:
           # generally be the case, and we can always relax this when presented with
           # specific situations where it is is a problem.
 
-          # commit author
-          commitauthor="$(git log -1 --pretty="%an <%ae>")"
+          # commit author email address
+          commitauthor="$(git log -1 --pretty="%ae")"
 
-          # signed-off-by trailer
+          # signed-off-by trailer email address. There is no way to parse just the
+          # email address from the trailer in the same way as git log, so instead
+          # grab the relevant trailer and then take the last whitespace-delimited
+          # part as the "<>" contained email address.
           # Getting the Signed-off-by trailer in this way causes blank
           # lines for some reason. Use awk to remove them.
-          commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | awk NF)"
+          commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | sed -ne 's/.* <\(.*\)>/\1/p')"
 
           if [[ "$commitauthor" != "$commitsigner" ]]; then
-          	echo "commit author does not match signed-off-by trailer"
+          	echo "commit author email address does not match signed-off-by trailer"
           	exit 1
           fi
       - name: Install Node

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -62,7 +62,7 @@ import (
 
 #earlyChecks: json.#step & {
 	name: "Early git and code sanity checks"
-	run: """
+	run: #"""
 		# Ensure the recent commit messages have Signed-off-by headers.
 		# TODO: Remove once this is enforced for admins too;
 		# see https://bugs.chromium.org/p/gerrit/issues/detail?id=15229
@@ -99,19 +99,22 @@ import (
 		# generally be the case, and we can always relax this when presented with
 		# specific situations where it is is a problem.
 
-		# commit author
-		commitauthor="$(git log -1 --pretty="%an <%ae>")"
+		# commit author email address
+		commitauthor="$(git log -1 --pretty="%ae")"
 
-		# signed-off-by trailer
+		# signed-off-by trailer email address. There is no way to parse just the
+		# email address from the trailer in the same way as git log, so instead
+		# grab the relevant trailer and then take the last whitespace-delimited
+		# part as the "<>" contained email address.
 		# Getting the Signed-off-by trailer in this way causes blank
 		# lines for some reason. Use awk to remove them.
-		commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | awk NF)"
+		commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | sed -ne 's/.* <\(.*\)>/\1/p')"
 
 		if [[ "$commitauthor" != "$commitsigner" ]]; then
-			echo "commit author does not match signed-off-by trailer"
+			echo "commit author email address does not match signed-off-by trailer"
 			exit 1
 		fi
-		"""
+		"""#
 }
 
 #cacheGoModules: json.#step & {


### PR DESCRIPTION
We currently perform a very naive check that the commit author (name and
email) exactly matches the Signed-off-by trailer. Gerrit, however, only
checks that the email address is the same.

Fix our simple check to only compare email address, which allows for
slight variations in the name in either the commit author and/or the
signed-off-by trailer.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I9a6c17dc14df273fd7eb398ddf39a9ec0a2eed5b
