### PR TITLE
Hugo: Next Arrow Bug

### DIFF
--- a/hugo/assets/scss/components/prevnext.scss
+++ b/hugo/assets/scss/components/prevnext.scss
@@ -42,8 +42,6 @@
     &__next {
         display: none;
         line-height: 1.5;
-        margin: 0 auto 0 0;
-        padding: 0.25rem 0.25rem 0.25rem 40px;
         position: relative;
         text-decoration: none;
         width: 100%;
@@ -59,6 +57,16 @@
         &[disabled] {
             display: none;
         }
+    }
+
+    &__prev {
+        padding: 0.25rem 0.25rem 0.25rem $p-gutter--large;
+        margin: 0 auto 0 0;
+    }
+
+    &__next {
+        padding: 0.25rem $p-gutter--large 0.25rem 0.25rem;
+        margin: 0 0 0 auto;
     }
 
     &__icon {


### PR DESCRIPTION
- Padding and margin reversed on next button compared to prev button

For: https://linear.app/usmedia/issue/CUE-173

Closes #327 as merged.

Signed-off-by: Eva van Dongen <eva.van.dongen@usmedia.nl>
Change-Id: If14a682a6d963bf06a901fd6e0f8d40c2f7d0caf
