### PR TITLE
Hugo: Fix scrolling issues in codeblock

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -346,13 +346,10 @@ pre {
     border: 1px solid var(--pre-border-color);
     border-radius: 5px;
     color: var(--pre-color);
-    height: 100%;
     margin: 0 0 1rem;
     max-width: 100%;
-    overflow: auto;
+    overflow-x: auto;
     padding: 1rem 1.25rem;
-    white-space: pre-wrap;
-    word-wrap: break-word;
 }
 
 audio,

--- a/hugo/assets/scss/components/columns.scss
+++ b/hugo/assets/scss/components/columns.scss
@@ -18,6 +18,19 @@
             flex: 0 1 50%;
             flex-direction: column;
             max-width: 50%;
+
+            // Make sure codeblocks fill all available space inside column
+            > pre:last-child {
+                flex: 1 0 auto;
+            }
+
+            > .highlight:last-child {
+                flex: 1 0 auto;
+
+                > * {
+                    height: 100%;
+                }
+            }
         }
     }
 }

--- a/hugo/assets/scss/components/highlight.scss
+++ b/hugo/assets/scss/components/highlight.scss
@@ -3,7 +3,6 @@
 @import '../mixins/screen';
 
 .highlight {
-    height: 100%;
     margin-bottom: 1rem;
     position: relative;
 

--- a/hugo/config/_default/config.toml
+++ b/hugo/config/_default/config.toml
@@ -14,11 +14,6 @@ disableAliases = true # We use Netlify server-side redirects instead of generate
 # Hugo allows theme composition (and inheritance). Precedence is from left to right.
 # theme = ["docsy"]
 
-# Highlighting
-[markup]
-    [markup.highlight]
-        lineNumbersInTable = false
-
 # Image processing
 [imaging]
     # See https://github.com/disintegration/imaging

--- a/hugo/config/_default/markup.toml
+++ b/hugo/config/_default/markup.toml
@@ -22,6 +22,7 @@ defaultMarkdownHandler = "goldmark"
 
 [highlight]
     style = "trac"
+    lineNumbersInTable = false
 
 [tableOfContents]
     endLevel = 2


### PR DESCRIPTION
- Move highlight config from config.toml to markup.toml
- Make sure horizontal overflow doesn't get wrapped but gets a scrollbar
- Make sure vertical overflow for pre doesn't get cut of but shows
  all content. Remove height: 100% from css because this only works when
  pre or highlight is the only child which is not the case.
- Use flex to make last highlight or pre tag in a column fill out the
  remaining space.

For: https://linear.app/usmedia/issue/CUE-177 and
     https://linear.app/usmedia/issue/CUE-176

Closes #330 as merged.

Signed-off-by: Jorinde Reijnierse <jorinde.reijnierse@usmedia.nl>
Change-Id: I5e9860bd147c7d77239146e00a2ff2aaf40150b2
