### PR TITLE
internal/functions: learn the order of numbers again

### DIFF
--- a/internal/functions/gerritstatusupdater/gerritstatusupdater.go
+++ b/internal/functions/gerritstatusupdater/gerritstatusupdater.go
@@ -251,8 +251,8 @@ func (c *localContext) setHeadBranch(b string) {
 	}
 	c.ChangeID = headBranchParts[1]
 	c.RevisionID = headBranchParts[2]
-	c.CL = headBranchParts[4]
-	c.Patchset = headBranchParts[3]
+	c.CL = headBranchParts[3]
+	c.Patchset = headBranchParts[4]
 }
 
 // ServeHTTP is the implementation of the gerritstatusupdater serverless


### PR DESCRIPTION
The CL number comes before the patchset in the branch name.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>
Change-Id: I6ce092254f75c7d755cca111b05e908fe3fb5805
