### PR TITLE
Hugo: show inline code like parent

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -332,12 +332,23 @@ pre {
 code {
     margin-bottom: 1rem;
 
-    dd &,
-    td &,
-    p & {
+    :is(dd, td, h1, h2, h3, h4, h5, h6, p, span, ul, ol) & {
         background-color: var(--pre-background-color);
         border-radius: $b-radius;
+        font-size: inherit;
+        font-style: normal;
+        line-height: inherit;
         padding: 3px 5px;
+    }
+
+    .section--blue &,
+    .section--grey & {
+        --pre-background-color: #{ $c-white };
+    }
+
+    .tree &,
+    .toc & {
+        --pre-background-color: #{ transparent };
     }
 }
 


### PR DESCRIPTION
- Inherit font size and line height from parent
- Always have a normal font style, eg no italic
- White code background when section is blue or grey

For
- https://linear.app/usmedia/issue/CUE-174
- https://linear.app/usmedia/issue/CUE-181

Closes #332 as merged.

Signed-off-by: Anne van Gorkom <anne.van.gorkom@usmedia.nl>
Change-Id: I088bb5fa3f3a13a421e44795cba9e7959f7246aa
