### PR TITLE
Hugo: show correct hover for multiple line texts

### DIFF
--- a/hugo/assets/scss/components/nav.scss
+++ b/hugo/assets/scss/components/nav.scss
@@ -42,7 +42,6 @@
 
     &__link {
         cursor: pointer;
-        display: block;
         text-decoration: none;
 
         &:hover,
@@ -67,7 +66,6 @@
     &__text {
         background: linear-gradient(var(--nav-link-border-color), var(--nav-link-border-color)) no-repeat 100% 100%;
         background-size: 0 var(--nav-link-border-width);
-        display: inline-block;
         position: relative;
         transition:
             background-color 0.2s ease-in-out,
@@ -154,6 +152,7 @@
         #{ $self }__link {
             background-color: $c-white;
             border-radius: $b-radius--round;
+            display: block;
             height: $h-button;
             padding: 11px;
             transition: color 0.2s;


### PR DESCRIPTION
When the hovered text is more than 1 line, show the hover animation on
all the lines, not only the last

For https://linear.app/usmedia/issue/CUE-182

Closes #333 as merged as of commit 01f46a6.

Signed-off-by: Anne van Gorkom <anne.van.gorkom@usmedia.nl>
Change-Id: I1d3405d0a526b11325dfcb385f26ee93255e8cf8
