### PR TITLE
site: fix /go redirects

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -49,13 +49,6 @@ jobs:
             ${{ steps.go-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-${{ github.run_id }}
           restore-keys: ${{ runner.os }}
-      - name: Ensure latest CUE
-        run: |-
-          GOPROXY=direct go get -d cuelang.org/go@latest
-          go mod tidy
-          cd play
-          GOPROXY=direct go get -d cuelang.org/go@latest
-          go mod tidy
       - name: Re-vendor play
         run: ./_scripts/revendorToolsInternal.bash
         working-directory: ./play

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -61,19 +61,19 @@ trybot: _base.#bashWorkflow & {
 				// are established by running each tool.
 				for v in _#cachePre {v},
 
-				json.#step & {
-					// The latest git clean check ensures that this call is effectively
-					// side effect-free. Using GOPROXY=direct ensures we don't accidentally
-					// hit a stale cache in the proxy.
-					name: "Ensure latest CUE"
-					run: """
-						GOPROXY=direct go get -d cuelang.org/go@latest
-						go mod tidy
-						cd play
-						GOPROXY=direct go get -d cuelang.org/go@latest
-						go mod tidy
-						"""
-				},
+				// json.#step & {
+				// 	// The latest git clean check ensures that this call is effectively
+				// 	// side effect-free. Using GOPROXY=direct ensures we don't accidentally
+				// 	// hit a stale cache in the proxy.
+				// 	name: "Ensure latest CUE"
+				// 	run: """
+				// 		GOPROXY=direct go get -d cuelang.org/go@latest
+				// 		go mod tidy
+				// 		cd play
+				// 		GOPROXY=direct go get -d cuelang.org/go@latest
+				// 		go mod tidy
+				// 		"""
+				// },
 
 				_#play & {
 					name: "Re-vendor play"

--- a/internal/ci/netlify/netlify.cue
+++ b/internal/ci/netlify/netlify.cue
@@ -62,7 +62,7 @@ config: #config & {
 
 	context: "deploy-preview": command: "bash build.bash -b $DEPLOY_URL"
 
-	redirects: [...{force: true, status: 302}]
+	redirects: [...{force: true, status: *302 | int}]
 	redirects: [{
 		from: "/cl/*"
 		to:   "https://review.gerrithub.io/c/:splat"
@@ -84,6 +84,14 @@ config: #config & {
 	}, {
 		from: "/s/community-calendar"
 		to:   "https://calendar.google.com/calendar/u/0?cid=Y19lNzkxMWQ5OWQ4ZGIyMmU2ZTVjMzhkMTVkNjY2ZTVlNjdiNWE5ODNkZWU4N2JmNTU2NDY3NzI1OGIxYjJhMTFhQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20"
+	}, {
+		from:   "/go"
+		to:     "/golang/go.html"
+		status: 200
+	}, {
+		from:   "/go/*"
+		to:     "/golang/go.html"
+		status: 200
 	}]
 }
 

--- a/layouts/index.redir
+++ b/layouts/index.redir
@@ -4,9 +4,6 @@
 # test at https://play.netlify.com/redirects  #
 ###############################################
 
-# Redirect golang vanity imports for cuelang.org
-/go/* go-get=1 /golang/go.html 200
-
 # Redirect default Netlify subdomain to primary domain
 https://cue.netlify.com/* https://cuelang.org/:splat 301!
 https://cuelang.org/docs/concepts/intro/ https://cuelang.org/docs/concepts/logic/ 301!

--- a/netlify.toml
+++ b/netlify.toml
@@ -56,3 +56,15 @@ command = "bash build.bash -b $DEPLOY_URL"
   status = 302
   force = true
 
+[[redirects]]
+  from = "/go"
+  to = "/golang/go.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/go/*"
+  to = "/golang/go.html"
+  status = 200
+  force = true
+


### PR DESCRIPTION
Recently we have seen a significant number of requests for /go?go-get=1
return 404 errors.

Also, somewhat counterintuitively, the bare path /go is configured to
404. As a Go developer, seeing the import path cuelang.org/go I might
reasonably expect https://cuelang.org/go to take me somewhere sensible.

As such, the current redirect requires ?go-get=1 to be present, but in
practice we are even seeing some of these fail.

The reason for this is unclear but would appear to be something
Netlify-related because nothing has changed on our side.

The main focus for now is to fix the 404s we are seeing. The simplest
way to do that is to make /go and /go/* both redirect to /golang/go.html
without any condition on a query parameter being present.

As part of this change, temporarily disable the check for the latest CUE
version. This step is regularly failing because of the increased number
of 404 errors. Once we fix the 404s, we can restore this step.

Following this change the following should all redirect to
/golang/go.html:

  /go
  /go?go-get=1
  /go/
  /go/?go-get=1
  /go/cmd/cue
  /go/cmd/cue?go-get=1

(the /go/cmd/cue example covers /go/*)

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I39411ccb033d307ced5501a2719cc082645d36c2
