### PR TITLE
internal/ci: reenable pull through proxy step in trybots

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -49,6 +49,13 @@ jobs:
             ${{ steps.go-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-${{ github.run_id }}
           restore-keys: ${{ runner.os }}
+      - name: Ensure latest CUE
+        run: |-
+          GOPROXY=direct go get -d cuelang.org/go@latest
+          go mod tidy
+          cd play
+          GOPROXY=direct go get -d cuelang.org/go@latest
+          go mod tidy
       - name: Re-vendor play
         run: ./_scripts/revendorToolsInternal.bash
         working-directory: ./play

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -61,19 +61,19 @@ trybot: _base.#bashWorkflow & {
 				// are established by running each tool.
 				for v in _#cachePre {v},
 
-				// json.#step & {
-				// 	// The latest git clean check ensures that this call is effectively
-				// 	// side effect-free. Using GOPROXY=direct ensures we don't accidentally
-				// 	// hit a stale cache in the proxy.
-				// 	name: "Ensure latest CUE"
-				// 	run: """
-				// 		GOPROXY=direct go get -d cuelang.org/go@latest
-				// 		go mod tidy
-				// 		cd play
-				// 		GOPROXY=direct go get -d cuelang.org/go@latest
-				// 		go mod tidy
-				// 		"""
-				// },
+				json.#step & {
+					// The latest git clean check ensures that this call is effectively
+					// side effect-free. Using GOPROXY=direct ensures we don't accidentally
+					// hit a stale cache in the proxy.
+					name: "Ensure latest CUE"
+					run: """
+						GOPROXY=direct go get -d cuelang.org/go@latest
+						go mod tidy
+						cd play
+						GOPROXY=direct go get -d cuelang.org/go@latest
+						go mod tidy
+						"""
+				},
 
 				_#play & {
 					name: "Re-vendor play"


### PR DESCRIPTION
Now that we have hopefully fixed the number of 404 errors related to
requests to /go and /go/, reenable the trybot step that ensures we are
using the latest version of the cuelang.org/go module as part of
cuelang.org.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I7d49688429b25001e77291df7bb5f0ed75b8ac20
