### PR TITLE
netlify: redirect /go/* to pkg.go.dev/cuelang.org/go/:splat

### DIFF
--- a/internal/ci/netlify/netlify.cue
+++ b/internal/ci/netlify/netlify.cue
@@ -85,14 +85,13 @@ config: #config & {
 		from: "/s/community-calendar"
 		to:   "https://calendar.google.com/calendar/u/0?cid=Y19lNzkxMWQ5OWQ4ZGIyMmU2ZTVjMzhkMTVkNjY2ZTVlNjdiNWE5ODNkZWU4N2JmNTU2NDY3NzI1OGIxYjJhMTFhQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20"
 	}, {
-		from:   "/go"
-		to:     "/golang/go.html"
-		status: 200
+		from: "/go"
+		to:   "/golang/go.html"
 	}, {
-		from:   "/go/*"
-		to:     "/golang/go.html"
-		status: 200
-	}]
+		from: "/go/*"
+		to:   "/golang/go.html?:splat"
+	},
+	]
 }
 
 #toToml: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -59,12 +59,12 @@ command = "bash build.bash -b $DEPLOY_URL"
 [[redirects]]
   from = "/go"
   to = "/golang/go.html"
-  status = 200
+  status = 302
   force = true
 
 [[redirects]]
   from = "/go/*"
-  to = "/golang/go.html"
-  status = 200
+  to = "/golang/go.html?:splat"
+  status = 302
   force = true
 

--- a/static/golang/go.html
+++ b/static/golang/go.html
@@ -7,5 +7,8 @@
 </head>
 <body>
 Nothing to see here; <a href="https://pkg.go.dev/cuelang.org/go/">see the package on pkg.go.dev</a>.
+<script>
+  location='https://pkg.go.dev/cuelang.org/go/'+location.search.slice(1);
+</script>
 </body>
 </html>


### PR DESCRIPTION
We currently serve a static HTML file in response to any request for
/go/*. This allows us to serve a go-import meta tag which is used by
cmd/go for resolving the remote import path cuelang.org/go.

The static HTML page currently redirects to
https://pkg.go.dev/cuelang.org/go regardless of the request path suffix,
the elements after /go. This means that a request for /go/cmd/cue
redirects to https://pkg.go.dev/cuelang.org/go, rather than the more
useful https://pkg.go.dev/cuelang.org/go/cmd/cue.

Fix that by using 302 redirects from /go and /go/* to
/golang/go.html?:splat, regardless of query parameter. This allows us to
continue serving the go-import meta tag from the single static HTML, and
with some simple JavaScript in the go.html page we use the query
parameter part of the URL to complete the path for the in-page redirect
to pkg.go.dev.

After this CL, all the following behaviour should result. The first
column is the original path on cuelang.org requested, the second is the
redirect result, the third is the result of the JavaScript redirect to
pkg.go.dev

|-------------------+--------------------------+----------------------|
| Original path     | cuelang.org redir        | pkg.go.dev JS redir  |
|-------------------+--------------------------+----------------------|
| /go               | /golang/go.html          | /cuelang.org/go      |
| /go/              | /golang/go.html          | /cuelang.org/go      |
| /go?go-get=1      | /golang/go.html?go-get=1 | /cuelang.org/go      |
| /go/?go-get=1     | /golang/go.html?go-get=1 | /cuelang.org/go      |
| /go/cue           | /golang/go.html?cue      | /cuelang.org/go/cue  |
| /go/cue/          | /golang/go.html?cue/     | /cuelang.org/go/cue/ |
| /go/cue?go-get=1  | /golang/go.html?cue      | /cuelang.org/go/cue  |
| /go/cue/?go-get=1 | /golang/go.html?cue/     | /cuelang.org/go/cue/ |
|-------------------+--------------------------+----------------------|

The one thing we should sense check immediately after merging this CL
and the deploy completing is the cmd/go is happy with the 302 redirect
to a static page. Hard to imagine it would be worried about that, but we
should check to be sure.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Iee4ffeacdddca08de7a5edd874036bafe406d918
