### PR TITLE
trybot/I2a5f477367fbb94c7eb3a7657cfbfb642a72a8cb/3c0a4de12fcb33c7055d5fe83c5c4c6e9da257bb/551434/1

### DIFF
--- a/.github/workflows/push_tip_to_trybot.yml
+++ b/.github/workflows/push_tip_to_trybot.yml
@@ -33,5 +33,5 @@ jobs:
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
           git remote add origin https://review.gerrithub.io/a/cue-lang/cuelang.org
           git remote add trybot https://github.com/cue-lang/cuelang.org-trybot
-          git fetch origin master alpha
-          git push trybot "refs/remotes/origin/*:refs/heads/*"
+          git fetch origin "${{ github.ref }}"
+          git push trybot "FETCH_HEAD:${{ github.ref }}"

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -19,6 +19,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Reset git directory modification times
+        run: touch -t 202211302355 $(find * -type d)
+      - name: Restore git file modification times
+        uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
       - name: Install Node
         uses: actions/setup-node@v3
         with:
@@ -32,23 +37,28 @@ jobs:
         with:
           hugo-version: 0.89.4
           extended: true
-      - id: npm-cache-dir
-        name: Get npm cache directory
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
       - id: go-mod-cache-dir
         name: Get go mod cache directory
         run: echo "dir=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
       - id: go-cache-dir
         name: Get go build/test cache directory
         run: echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
-      - uses: actions/cache@v3
+      - if: ()
+        uses: actions/cache@v3
         with:
           path: |-
-            ${{ steps.npm-cache-dir.outputs.dir }}
             ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
             ${{ steps.go-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}
+          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
+      - if: '! ()'
+        uses: actions/cache/restore@v3
+        with:
+          path: |-
+            ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
+            ${{ steps.go-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
       - name: Ensure latest CUE
         run: |-
           GOPROXY=direct go get -d cuelang.org/go@latest
@@ -76,7 +86,7 @@ jobs:
         working-directory: ./play
       - name: Dist
         run: ./build.bash
-      - name: Verify commit is clean
+      - name: Check that git is clean at the end of the job
         run: test -z "$(git status --porcelain)" || (git status; git diff; false)
       - id: alias
         if: ${{github.repository == 'cue-lang/cuelang.org-trybot' && startsWith(github.head_ref, 'trybot/')}}
@@ -88,4 +98,4 @@ jobs:
         run: 'netlify deploy --alias ${{ steps.alias.outputs.alias }} -f functions -d _public -m "Deploy preview of CL" -s cue-cls --debug '
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN_CUE_CLS}}
-      - run: find '${{ steps.npm-cache-dir.outputs.dir }}' '${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download' '${{ steps.go-cache-dir.outputs.dir }}' -type f -amin +7200 -delete -print
+      - run: find '${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download' '${{ steps.go-cache-dir.outputs.dir }}' -type f -amin +7200 -delete -print

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -4,9 +4,9 @@ name: TryBot
 "on":
   push:
     branches:
+      - ci/test
       - master
       - alpha
-      - ci/test
   pull_request: {}
 jobs:
   test:

--- a/.github/workflows/trybot_dispatch.yml
+++ b/.github/workflows/trybot_dispatch.yml
@@ -31,10 +31,10 @@ jobs:
           git config user.name cueckoo
           git config user.email cueckoo@gmail.com
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
-          git fetch https://review.gerrithub.io/a/cue-lang/cuelang.org ${{ github.event.client_payload.payload.ref }}
+          git fetch https://review.gerrithub.io/a/cue-lang/cuelang.org "${{ github.event.client_payload.payload.ref }}"
           git checkout -b trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }} FETCH_HEAD
           git remote add origin https://github.com/cue-lang/cuelang.org-trybot
-          git fetch origin ${{ github.event.client_payload.payload.branch }}
+          git fetch origin "${{ github.event.client_payload.payload.branch }}"
           git push origin trybot/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}
           echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
-          gh pr -R https://github.com/cue-lang/cuelang.org-trybot create -B ${{ github.event.client_payload.payload.branch }} -f
+          gh pr --repo=https://github.com/cue-lang/cuelang.org-trybot create --base="${{ github.event.client_payload.payload.branch }}" --fill

--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -26,7 +26,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: master
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Reset git directory modification times
+        run: touch -t 202211302355 $(find * -type d)
+      - name: Restore git file modification times
+        uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
       - name: Install Node
         uses: actions/setup-node@v3
         with:
@@ -40,23 +45,28 @@ jobs:
         with:
           hugo-version: 0.89.4
           extended: true
-      - id: npm-cache-dir
-        name: Get npm cache directory
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
       - id: go-mod-cache-dir
         name: Get go mod cache directory
         run: echo "dir=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
       - id: go-cache-dir
         name: Get go build/test cache directory
         run: echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
-      - uses: actions/cache@v3
+      - if: ()
+        uses: actions/cache@v3
         with:
           path: |-
-            ${{ steps.npm-cache-dir.outputs.dir }}
             ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
             ${{ steps.go-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}
+          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
+      - if: '! ()'
+        uses: actions/cache/restore@v3
+        with:
+          path: |-
+            ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
+            ${{ steps.go-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
       - name: Tip dist
         run: ./build.bash
         env:
@@ -67,4 +77,4 @@ jobs:
         run: netlify deploy  -f functions -d _public -m "Deploy tip" -s cue-tip --debug --prod
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN_CUE_TIP}}
-      - run: find '${{ steps.npm-cache-dir.outputs.dir }}' '${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download' '${{ steps.go-cache-dir.outputs.dir }}' -type f -amin +7200 -delete -print
+      - run: find '${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download' '${{ steps.go-cache-dir.outputs.dir }}' -type f -amin +7200 -delete -print

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -12,11 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package core is a collection of features that are common to CUE projects and
-// the workflows they specify.
+// package base is a collection of workflows, jobs, stes etc that are common to
+// CUE projects and the workflows they specify. The package itself needs to be
+// instantiated to parameterise many of the exported definitions.
+//
+// For example a package using base would do something like this:
+//
+//     package workflows
+//
+//     import "cuelang.org/go/internal/ci/base"
+//
+//     // Create an instance of base
+//     _base: base & {
+//         #repositoryURL:                core.#githubRepositoryURL
+//         #defaultBranch:                core.#defaultBranch
+//         #botGitHubUser:                "cueckoo"
+//         #botGitHubUserTokenSecretsKey: "CUECKOO_GITHUB_PAT"
+//     }
+//
 package base
 
 import (
+	"list"
 	"strings"
 	"path"
 	"strconv"
@@ -25,23 +42,19 @@ import (
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
+// Package parameters
 #repositoryURL:                string
 #defaultBranch:                string
 #testDefaultBranch:            "ci/test"
 #botGitHubUser:                string
 #botGitHubUserTokenSecretsKey: string
+#protectedBranchPatterns: [...string]
+#releaseTagPattern: string
 
 #doNotEditMessage: {
 	#generatedBy: string
 	"Code generated \(#generatedBy); DO NOT EDIT."
 }
-
-// #isDefaultBranch is an expression that evaluates to true if the
-// job is running as a result of pushing to the default branch, like master.
-// For the sake of testing CI, pushes to #testDefaultBranch branch also match.
-// It would be nice to use the "contains" builtin for simplicity,
-// but array literals are not yet supported in expressions.
-#isDefaultBranch: "github.ref == 'refs/heads/\(#defaultBranch)' || github.ref == 'refs/heads/\(#testDefaultBranch)'"
 
 #bashWorkflow: json.#Workflow & {
 	jobs: [string]: defaults: run: shell: "bash"
@@ -55,10 +68,39 @@ import (
 	}
 }
 
-#checkoutCode: json.#step & {
-	name: "Checkout code"
-	uses: "actions/checkout@v3"
-}
+#checkoutCode: [
+	json.#step & {
+		name: "Checkout code"
+		uses: "actions/checkout@v3"
+
+		// "pull_request" builds will by default use a merge commit,
+		// testing the PR's HEAD merged on top of the master branch.
+		// For consistency with Gerrit, avoid that merge commit entirely.
+		// This doesn't affect builds by other events like "push",
+		// since github.event.pull_request is unset so ref remains empty.
+		with: {
+			ref:           "${{ github.event.pull_request.head.sha }}"
+			"fetch-depth": 0 // see the docs below
+		}
+	},
+	// Restore modified times to work around https://go.dev/issues/58571,
+	// as otherwise we would get lots of unnecessary Go test cache misses.
+	// Note that this action requires actions/checkout to use a fetch-depth of 0.
+	// Since this is a third-party action which runs arbitrary code,
+	// we pin a commit hash for v2 to be in control of code updates.
+	// Also note that git-restore-mtime does not update all directories,
+	// per the bug report at https://github.com/MestreLion/git-tools/issues/47,
+	// so we first reset all directory timestamps to a static time as a fallback.
+	// TODO(mvdan): May be unnecessary once the Go bug above is fixed.
+	json.#step & {
+		name: "Reset git directory modification times"
+		run:  "touch -t 202211302355 $(find * -type d)"
+	},
+	json.#step & {
+		name: "Restore git file modification times"
+		uses: "chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe"
+	},
+]
 
 #earlyChecks: json.#step & {
 	name: "Early git and code sanity checks"
@@ -76,18 +118,6 @@ import (
 			fi
 		done
 		"""
-}
-
-#cacheGoModules: json.#step & {
-	name: "Cache Go modules"
-	uses: "actions/cache@v3"
-	with: {
-		path: "~/go/pkg/mod"
-		key:  "${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}"
-		"restore-keys": """
-			${{ runner.os }}-${{ matrix.go-version }}-go-
-			"""
-	}
 }
 
 #checkGitClean: json.#step & {
@@ -111,8 +141,180 @@ let _#botGitHubUserTokenSecretsKey = #botGitHubUserTokenSecretsKey
 
 	name: string
 	run:  #"""
-			\#(#curl) -H "Content-Type: application/json" -u \#(#botGitHubUser):${{ secrets.\#(#botGitHubUserTokenSecretsKey) }} --request POST --data-binary \#(strconv.Quote(encjson.Marshal(#arg))) https://api.github.com/repos/\#(_#repositoryPath)/dispatches
+			\#(#curlGitHubAPI) -f --request POST --data-binary \#(strconv.Quote(encjson.Marshal(#arg))) https://api.github.com/repos/\#(_#repositoryPath)/dispatches
 			"""#
 }
 
-#curl: "curl -f -s"
+#curlGitHubAPI: #"""
+	curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.\#(#botGitHubUserTokenSecretsKey) }}" -H "X-GitHub-Api-Version: 2022-11-28"
+	"""#
+
+// #codeReview defines the schema of a codereview.cfg file that
+// sits at the root of a repository. codereview.cfg is the configuration
+// file that drives golang.org/x/review/git-codereview. This config
+// file is also used by github.com/cue-sh/tools/cmd/cueckoo.
+#codeReview: {
+	gerrit?:      string
+	github?:      string
+	"cue-unity"?: string
+}
+
+// #toCodeReviewCfg converts a #codeReview instance to
+// the key: value
+#toCodeReviewCfg: {
+	#input: #codeReview
+	let parts = [ for k, v in #input {k + ": " + v}]
+
+	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
+	strings.Join(parts, "\n")
+}
+
+// #URLPath is a temporary measure to derive the path part of a URL.
+//
+// TODO: remove when cuelang.org/issue/1433 lands.
+#URLPath: {
+	#url: string
+	let parts = strings.Split(#url, "/")
+	strings.Join(list.Slice(parts, 3, len(parts)), "/")
+}
+
+#setupGoActionsCaches: {
+	// #protectedBranchExpr is a GitHub expression
+	// (https://docs.github.com/en/actions/learn-github-actions/expressions)
+	// that evaluates to true if the workflow is running for a commit against a
+	// protected branch.
+	#protectedBranchExpr: string
+
+	let goModCacheDirID = "go-mod-cache-dir"
+	let goCacheDirID = "go-cache-dir"
+
+	// cacheDirs is a convenience variable that includes
+	// GitHub expressions that represent the directories
+	// that participate in Go caching.
+	let cacheDirs = [ "${{ steps.\(goModCacheDirID).outputs.dir }}/cache/download", "${{ steps.\(goCacheDirID).outputs.dir }}"]
+
+	// pre is the list of steps required to establish and initialise the correct
+	// caches for Go-based workflows.
+	pre: [
+		json.#step & {
+			name: "Get go mod cache directory"
+			id:   goModCacheDirID
+			run:  #"echo "dir=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}"#
+		},
+		json.#step & {
+			name: "Get go build/test cache directory"
+			id:   goCacheDirID
+			run:  #"echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}"#
+		},
+		for _, v in [
+			{
+				if:   #protectedBranchExpr
+				uses: "actions/cache@v3"
+			},
+			{
+				if:   "! \(#protectedBranchExpr)"
+				uses: "actions/cache/restore@v3"
+			},
+		] {
+			v & json.#step & {
+				with: {
+					path: strings.Join(cacheDirs, "\n")
+
+					// GitHub actions caches are immutable. Therefore, use a key which is
+					// unique, but allow the restore to fallback to the most recent cache.
+					// The result is then saved under the new key which will benefit the
+					// next build
+					key:            "${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}"
+					"restore-keys": "${{ runner.os }}-${{ matrix.go-version }}"
+				}
+			}
+		},
+	]
+
+	// post is the list of steps that need to be run at the end of
+	// a workflow to "tidy up" following the earlier pre
+	post: [
+		json.#step & {
+			let qCacheDirs = [ for v in cacheDirs {"'\(v)'"}]
+			run: "find \(strings.Join(qCacheDirs, " ")) -type f -amin +7200 -delete -print"
+		},
+	]
+}
+
+// #codeReview defines the schema of a codereview.cfg file that
+// sits at the root of a repository. codereview.cfg is the configuration
+// file that drives golang.org/x/review/git-codereview. This config
+// file is also used by github.com/cue-sh/tools/cmd/cueckoo.
+#codeReview: {
+	gerrit?:      string
+	github?:      string
+	"cue-unity"?: string
+}
+
+// #toCodeReviewCfg converts a #codeReview instance to
+// the key: value
+#toCodeReviewCfg: {
+	#input: #codeReview
+	let parts = [ for k, v in #input {k + ": " + v}]
+
+	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
+	strings.Join(parts, "\n")
+}
+
+// _#matchPattern returns a GitHub Actions expression which evaluates whether a
+// variable matches a globbing pattern. For literal patterns it uses "==",
+// and for suffix patterns it uses "startsWith".
+// See https://docs.github.com/en/actions/learn-github-actions/expressions.
+_#matchPattern: {
+	variable: string
+	pattern:  string
+	expr:     [
+			if strings.HasSuffix(pattern, "*") {
+			let prefix = strings.TrimSuffix(pattern, "*")
+			"startsWith(\(variable), '\(prefix)')"
+		},
+		{
+			"\(variable) == '\(pattern)'"
+		},
+	][0]
+}
+
+// #isProtectedBranch is an expression that evaluates to true if the
+// job is running as a result of pushing to one of _#protectedBranchPatterns.
+// It would be nice to use the "contains" builtin for simplicity,
+// but array literals are not yet supported in expressions.
+#isProtectedBranch: {
+	"(" + strings.Join([ for branch in #protectedBranchPatterns {
+		(_#matchPattern & {variable: "github.ref", pattern: "refs/heads/\(branch)"}).expr
+	}], " || ") + ")"
+}
+
+// #isReleaseTag creates a GitHub expression, based on the given release tag
+// pattern, that evaluates to true if called in the context of a workflow that
+// is part of a release.
+#isReleaseTag: {
+	(_#matchPattern & {variable: "github.ref", pattern: "refs/tags/\(#releaseTagPattern)"}).expr
+}
+
+// Define some shared keys and human-readable names.
+//
+// #trybot.key and #unity.key are shared with
+// github.com/cue-sh/tools/cmd/cueckoo.  The keys are used across various CUE
+// workflows and their consistency in those various locations is therefore
+// crucial. As such, we assert specific values for the keys here rather than
+// just deriving values from the human-readable names.
+//
+// #trybot.name is by the trybot GitHub workflow and by gerritstatusupdater as
+// an identifier in the status updates that are posted as reviews for this
+// workflows, but also as the result label key, e.g.  "TryBot-Result" would be
+// the result label key for the "TryBot" workflow. This name also shows up in
+// the CI badge in the top-level README.
+#trybot: {
+	key:  "trybot" & strings.ToLower(name)
+	name: "TryBot"
+}
+
+#unity: {
+	key:  "unity" & strings.ToLower(name)
+	name: "Unity"
+}

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -40,12 +40,13 @@ _goos: string @tag(os,var=os)
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
 command: gen: workflows: {
-	for w in github.workflows {
-		"\(w.file)": file.Create & {
+	for _workflowName, _workflow in github.workflows {
+		let _filename = _workflowName + ".yml"
+		(_filename): file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
-			filename: path.Join([_dir, w.file], _goos)
+			filename: path.Join([_dir, _filename], _goos)
 			let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
-			contents: "# \(donotedit)\n\n\(yaml.Marshal(w.schema))"
+			contents: "# \(donotedit)\n\n\(yaml.Marshal(_workflow))"
 		}
 	}
 }

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -22,7 +22,7 @@ import (
 	"github.com/cue-lang/cuelang.org/internal/ci/base"
 	"github.com/cue-lang/cuelang.org/internal/ci/core"
 	"github.com/cue-lang/cuelang.org/internal/ci/github"
-	"github.com/cue-lang/cuelang.org/internal/ci/netlify"
+	_netlify "github.com/cue-lang/cuelang.org/internal/ci/netlify"
 )
 
 // For the commands below, note we use simple yet hacky path resolution, rather
@@ -34,13 +34,12 @@ import (
 
 _goos: string @tag(os,var=os)
 
-// genworkflows regenerates the GitHub workflow Yaml definitions.
+// gen.workflows regenerates the GitHub workflow Yaml definitions.
 //
 // See internal/ci/gen.go for details on how this step fits into the sequence
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
-command: genworkflows: {
-
+command: gen: workflows: {
 	for w in github.workflows {
 		"\(w.file)": file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
@@ -51,10 +50,10 @@ command: genworkflows: {
 	}
 }
 
-command: gennetlify: file.Create & {
+command: gen: netlify: file.Create & {
 	_dir:     path.FromSlash("../../", path.Unix)
 	filename: path.Join([_dir, "netlify.toml"], _goos)
-	let res = netlify.#toToml & {#input: netlify.config, _}
+	let res = _netlify.#toToml & {#input: _netlify.config, _}
 	let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
 	contents: "# \(donotedit)\n\n\(res)\n"
 }

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -1,3 +1,6 @@
+// package core contains data values that are commont to all CUE
+// configurations.  This not only includes GitHub workflows, but also things
+// like gerrit configuration etc.
 package core
 
 import (

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -4,8 +4,7 @@
 package core
 
 import (
-	"list"
-	"strings"
+	"github.com/cue-lang/cuelang.org/internal/ci/base"
 )
 
 // The machines that we use
@@ -16,7 +15,7 @@ windowsMachine: "windows-2022"
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
 githubRepositoryURL:  "https://github.com/cue-lang/cuelang.org"
 gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cuelang.org"
-githubRepositoryPath: _#URLPath & {#url: githubRepositoryURL, _}
+githubRepositoryPath: base.#URLPath & {#url: githubRepositoryURL, _}
 
 // Use the latest Go version for extra checks,
 // such as running tests with the data race detector.
@@ -55,17 +54,9 @@ releaseTagPrefix: "v"
 // releaseTagPrefix.
 releaseTagPattern: releaseTagPrefix + "*"
 
-codeReview: #codeReview & {
+codeReview: base.#codeReview & {
 	github: githubRepositoryURL
 	gerrit: gerritRepositoryURL
-}
-
-// Not ideal, but hack together something that gives us the path
-// of a URL. In lieu of cuelang.org/issue/1433
-_#URLPath: {
-	#url: string
-	let parts = strings.Split(#url, "/")
-	strings.Join(list.Slice(parts, 3, len(parts)), "/")
 }
 
 // protectedBranchPatterns is a list of glob patterns to match the protected
@@ -74,19 +65,3 @@ _#URLPath: {
 // but excludes any others like feature branches or short-lived branches.
 // Note that ci/test is excluded as it is GitHub-only.
 protectedBranchPatterns: [defaultBranch, "alpha"]
-
-#codeReview: {
-	gerrit?: string
-	github?: string
-	unity?:  string
-}
-
-// #toCodeReviewCfg converts a #codeReview instance to
-// the key: value
-#toCodeReviewCfg: {
-	#input: #codeReview
-	let parts = [ for k, v in #input {k + ": " + v}]
-
-	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
-	strings.Join(parts, "\n")
-}

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -9,9 +9,9 @@ import (
 )
 
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
-#githubRepositoryURL:  "https://github.com/cue-lang/cuelang.org"
-#gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cuelang.org"
-#githubRepositoryPath: _#URLPath & {#url: #githubRepositoryURL, _}
+githubRepositoryURL:  "https://github.com/cue-lang/cuelang.org"
+gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cuelang.org"
+githubRepositoryPath: _#URLPath & {#url: githubRepositoryURL, _}
 
 // Not ideal, but hack together something that gives us the path
 // of a URL. In lieu of cuelang.org/issue/1433
@@ -24,20 +24,20 @@ _#URLPath: {
 // Use a specific latest version for release builds.
 // Note that we don't want ".x" for the sake of reproducibility,
 // so we instead pin a specific Go release.
-#goVersion: "1.19.3"
+goVersion: "1.19.3"
 
 // Use a specific version of NodeJS for deploy purposes. This version
 // is consistent between netlify and GitHub Actions usage.
-#nodeVersion: "18.8.0"
+nodeVersion: "18.8.0"
 
 // hugoVersion is the version of hugo used in generating our static site
-#hugoVersion: "0.89.4"
+hugoVersion: "0.89.4"
 
 // netlifyCLIVersion is the version of the Netlify CLI used to deploy tip and
 // deploy previews of CLs
-#netlifyCLIVersion: "12.4.0"
+netlifyCLIVersion: "12.4.0"
 
-#netlifySites: {
+netlifySites: {
 	cls: "cue-cls"
 	tip: "cue-tip"
 }
@@ -49,8 +49,8 @@ _#URLPath: {
 }
 
 codeReview: #codeReview & {
-	github: #githubRepositoryURL
-	gerrit: #gerritRepositoryURL
+	github: githubRepositoryURL
+	gerrit: gerritRepositoryURL
 }
 
 // #toCodeReviewCfg converts a #codeReview instance to

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -8,18 +8,21 @@ import (
 	"strings"
 )
 
+// The machines that we use
+linuxMachine:   "ubuntu-20.04"
+macosMachine:   "macos-11"
+windowsMachine: "windows-2022"
+
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
 githubRepositoryURL:  "https://github.com/cue-lang/cuelang.org"
 gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cuelang.org"
 githubRepositoryPath: _#URLPath & {#url: githubRepositoryURL, _}
 
-// Not ideal, but hack together something that gives us the path
-// of a URL. In lieu of cuelang.org/issue/1433
-_#URLPath: {
-	#url: string
-	let parts = strings.Split(#url, "/")
-	strings.Join(list.Slice(parts, 3, len(parts)), "/")
-}
+// Use the latest Go version for extra checks,
+// such as running tests with the data race detector.
+latestStableGo: "1.19.x"
+
+goreleaserVersion: "v1.13.1"
 
 // Use a specific latest version for release builds.
 // Note that we don't want ".x" for the sake of reproducibility,
@@ -42,15 +45,40 @@ netlifySites: {
 	tip: "cue-tip"
 }
 
-#codeReview: {
-	gerrit?: string
-	github?: string
-	unity?:  string
-}
+defaultBranch: "master"
+
+// releaseTagPrefix is the prefix used to identify all git tag that correspond
+// to semver releases
+releaseTagPrefix: "v"
+
+// releaseTagPattern is the GitHub glob pattern that corresponds to
+// releaseTagPrefix.
+releaseTagPattern: releaseTagPrefix + "*"
 
 codeReview: #codeReview & {
 	github: githubRepositoryURL
 	gerrit: gerritRepositoryURL
+}
+
+// Not ideal, but hack together something that gives us the path
+// of a URL. In lieu of cuelang.org/issue/1433
+_#URLPath: {
+	#url: string
+	let parts = strings.Split(#url, "/")
+	strings.Join(list.Slice(parts, 3, len(parts)), "/")
+}
+
+// protectedBranchPatterns is a list of glob patterns to match the protected
+// git branches which are continuously used during development on Gerrit.
+// This includes the default branch and release branches,
+// but excludes any others like feature branches or short-lived branches.
+// Note that ci/test is excluded as it is GitHub-only.
+protectedBranchPatterns: [defaultBranch, "alpha"]
+
+#codeReview: {
+	gerrit?: string
+	github?: string
+	unity?:  string
 }
 
 // #toCodeReviewCfg converts a #codeReview instance to

--- a/internal/ci/gen.go
+++ b/internal/ci/gen.go
@@ -14,7 +14,7 @@
 
 package ci
 
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd importjsonschema ./vendor
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd genworkflows
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd gennetlify
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd gencodereviewcfg
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd importjsonschema ./vendor
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd genworkflows
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gennetlify
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gencodereviewcfg

--- a/internal/ci/gen.go
+++ b/internal/ci/gen.go
@@ -15,6 +15,4 @@
 package ci
 
 //go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd importjsonschema ./vendor
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd genworkflows
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gennetlify
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gencodereviewcfg
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gen

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -34,7 +34,7 @@ workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	jobs: push: {
 		"runs-on": _#linuxMachine
-		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_gerrithub.#writeNetrcFile,
 			json.#step & {

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -27,13 +27,13 @@ workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {
-		push: branches: _#protectedBranchPatterns
+		push: branches: core.protectedBranchPatterns
 	}
 
 	concurrency: "push_tip_to_trybot"
 
 	jobs: push: {
-		"runs-on": _#linuxMachine
+		"runs-on": core.linuxMachine
 		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_gerrithub.#writeNetrcFile,

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -15,19 +15,19 @@
 package github
 
 import (
-	"strings"
-
 	"github.com/cue-lang/cuelang.org/internal/ci/core"
 
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
-// push_tip_to_trybot "syncs" active branches to the trybot repo
+// push_tip_to_trybot "syncs" active branches to the trybot repo.
+// Since the workflow is triggered by a push to any of the branches,
+// the step only needs to sync the pushed branch.
 workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {
-		push: branches: _#activeBranches
+		push: branches: _#protectedBranchPatterns
 	}
 
 	concurrency: "push_tip_to_trybot"
@@ -48,8 +48,8 @@ workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 						git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n \(_gerrithub.#botGitHubUser):${{ secrets.\(_gerrithub.#botGitHubUserTokenSecretsKey) }} | base64)"
 						git remote add origin \(_gerrithub.#gerritHubRepository)
 						git remote add trybot \(_gerrithub.#trybotRepositoryURL)
-						git fetch origin \(strings.Join(_#activeBranches, " "))
-						git push trybot "refs/remotes/origin/*:refs/heads/*"
+						git fetch origin "${{ github.ref }}"
+						git push trybot "FETCH_HEAD:${{ github.ref }}"
 						"""
 			},
 		]

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -23,7 +23,7 @@ import (
 )
 
 // push_tip_to_trybot "syncs" active branches to the trybot repo
-push_tip_to_trybot: _base.#bashWorkflow & {
+workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -25,7 +25,7 @@ import (
 )
 
 // The trybot workflow.
-trybot: _base.#bashWorkflow & {
+workflows: trybot: _base.#bashWorkflow & {
 	// Note: the name of this workflow is used by gerritstatusupdater as an
 	// identifier in the status updates that are posted as reviews for this
 	// workflows, but also as the result label key, e.g. "TryBot-Result" would

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -122,7 +122,7 @@ workflows: trybot: _base.#bashWorkflow & {
 				//     trybot/I01e0e139902da54151659fe595f23dd519f54637/2e79979116f96a26c9240e0e9c55b31d4311cf93/547774/11
 				//
 				json.#step & {
-					if: "${{github.repository == '\(core.#githubRepositoryPath)-trybot' && startsWith(github.head_ref, 'trybot/')}}"
+					if: "${{github.repository == '\(core.githubRepositoryPath)-trybot' && startsWith(github.head_ref, 'trybot/')}}"
 					id: "alias"
 
 					// Use github.head_ref per
@@ -138,8 +138,8 @@ workflows: trybot: _base.#bashWorkflow & {
 				// Only run a deploy of tip if we are running as part of the trybot repo,
 				// with a branch name that matches the trybot pattern
 				_#netlifyDeploy & {
-					if:     "${{github.repository == '\(core.#githubRepositoryPath)-trybot' && startsWith(github.head_ref, 'trybot/')}}"
-					#site:  core.#netlifySites.cls
+					if:     "${{github.repository == '\(core.githubRepositoryPath)-trybot' && startsWith(github.head_ref, 'trybot/')}}"
+					#site:  core.netlifySites.cls
 					#alias: "${{ steps.alias.outputs.alias }}"
 					name:   "Deploy preview of CL"
 				},
@@ -173,19 +173,19 @@ _#installNode: json.#step & {
 	name: "Install Node"
 	uses: "actions/setup-node@v3"
 	with: {
-		"node-version": core.#nodeVersion
+		"node-version": core.nodeVersion
 	}
 }
 
 _#installGo: _base.#installGo & {
-	with: "go-version": core.#goVersion
+	with: "go-version": core.goVersion
 }
 
 _#installHugo: json.#step & {
 	name: "Install Hugo"
 	uses: "peaceiris/actions-hugo@v2"
 	with: {
-		"hugo-version": core.#hugoVersion
+		"hugo-version": core.hugoVersion
 		extended:       true
 	}
 }
@@ -202,7 +202,7 @@ _#tipDist: _#dist & {
 
 _#installNetlifyCLI: json.#step & {
 	name: "Install Netlify CLI"
-	run:  "npm install -g netlify-cli@\(core.#netlifyCLIVersion)"
+	run:  "npm install -g netlify-cli@\(core.netlifyCLIVersion)"
 }
 
 // _#netlifyDeploy is used to push CLs for preview but also to deploy tip

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -15,6 +15,7 @@
 package github
 
 import (
+	"list"
 	"strings"
 	"strconv"
 
@@ -37,7 +38,7 @@ workflows: trybot: _base.#bashWorkflow & {
 
 	on: {
 		push: {
-			branches: [ for v in _#activeBranches {v}, _base.#testDefaultBranch]
+			branches: list.Concat([[_base.#testDefaultBranch], _#protectedBranchPatterns])
 		}
 		pull_request: {}
 	}

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -46,21 +46,17 @@ workflows: trybot: _base.#bashWorkflow & {
 	jobs: {
 		test: {
 			"runs-on": core.linuxMachine
+
 			steps: [
-				_base.#checkoutCode & {
-					// "pull_request" builds will by default use a merge commit,
-					// testing the PR's HEAD merged on top of the master branch.
-					// For consistency with Gerrit, avoid that merge commit entirely.
-					// This doesn't affect "push" builds, which never used merge commits.
-					with: ref: "${{ github.event.pull_request.head.sha }}"
-				},
+				for v in _base.#checkoutCode {v},
+
 				_#installNode,
 				_#installGo,
 				_#installHugo,
 
 				// cachePre must come after installing Node and Go, because the cache locations
 				// are established by running each tool.
-				for v in _#cachePre {v},
+				for v in _goCaches.pre {v},
 
 				json.#step & {
 					// The latest git clean check ensures that this call is effectively
@@ -107,12 +103,7 @@ workflows: trybot: _base.#bashWorkflow & {
 
 				_#dist,
 
-				json.#step & {
-					name: "Verify commit is clean"
-					run: """
-						test -z "$(git status --porcelain)" || (git status; git diff; false)
-						"""
-				},
+				_base.#checkGitClean,
 
 				// GitHub offers very limited expressions at runtime of a workflow.
 				// Instead we have to resort to dropping down to shell and then
@@ -145,7 +136,7 @@ workflows: trybot: _base.#bashWorkflow & {
 					name:   "Deploy preview of CL"
 				},
 
-				_#cachePost,
+				for v in _goCaches.post {v},
 			]
 		}
 	}

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -38,14 +38,14 @@ workflows: trybot: _base.#bashWorkflow & {
 
 	on: {
 		push: {
-			branches: list.Concat([[_base.#testDefaultBranch], _#protectedBranchPatterns])
+			branches: list.Concat([[_base.#testDefaultBranch], core.protectedBranchPatterns])
 		}
 		pull_request: {}
 	}
 
 	jobs: {
 		test: {
-			"runs-on": _#linuxMachine
+			"runs-on": core.linuxMachine
 			steps: [
 				_base.#checkoutCode & {
 					// "pull_request" builds will by default use a merge commit,
@@ -147,6 +147,14 @@ workflows: trybot: _base.#bashWorkflow & {
 
 				_#cachePost,
 			]
+		}
+	}
+
+	_#testStrategy: {
+		"fail-fast": false
+		matrix: {
+			"go-version": ["1.18.x", core.latestStableGo]
+			os: [core.linuxMachine, core.macosMachine, core.windowsMachine]
 		}
 	}
 

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -15,6 +15,6 @@
 package github
 
 // The trybot_dispatch workflow.
-trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
+workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
 	#type: _gerrithub.#dispatchTrybot
 }

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -15,6 +15,4 @@
 package github
 
 // The trybot_dispatch workflow.
-workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
-	#type: _gerrithub.#dispatchTrybot
-}
+workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#trybotWorkflow

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -43,16 +43,16 @@ workflows: update_tip: _base.#bashWorkflow & {
 
 		steps: [
 			_gerrithub.#writeNetrcFile,
-			_base.#checkoutCode & {
-				with: ref: core.defaultBranch
-			},
+
+			for v in _base.#checkoutCode {v},
+
 			_#installNode,
 			_#installGo,
 			_#installHugo,
 
 			// cachePre must come after installing Node and Go, because the cache locations
 			// are established by running each tool.
-			for v in _#cachePre {v},
+			for v in _goCaches.pre {v},
 
 			_#tipDist,
 			_#installNetlifyCLI,
@@ -61,7 +61,8 @@ workflows: update_tip: _base.#bashWorkflow & {
 				#site: core.netlifySites.tip
 				name:  "Deploy tip"
 			},
-			_#cachePost,
+
+			for v in _goCaches.post {v},
 		]
 	}
 }

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -23,7 +23,7 @@ workflows: update_tip: _base.#bashWorkflow & {
 
 	name: "Update tip"
 	on: {
-		push: branches: [_#defaultBranch]
+		push: branches: [core.defaultBranch]
 		repository_dispatch: {}
 	}
 
@@ -33,7 +33,7 @@ workflows: update_tip: _base.#bashWorkflow & {
 	concurrency: "deploy"
 
 	jobs: push: {
-		"runs-on": _#linuxMachine
+		"runs-on": core.linuxMachine
 
 		// Only run this workflow in the main repository, and if we are triggered
 		// by repository_dispatch (which will happen if the cue-lang/cue repo
@@ -44,7 +44,7 @@ workflows: update_tip: _base.#bashWorkflow & {
 		steps: [
 			_gerrithub.#writeNetrcFile,
 			_base.#checkoutCode & {
-				with: ref: _#defaultBranch
+				with: ref: core.defaultBranch
 			},
 			_#installNode,
 			_#installGo,
@@ -64,5 +64,4 @@ workflows: update_tip: _base.#bashWorkflow & {
 			_#cachePost,
 		]
 	}
-
 }

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -19,7 +19,7 @@ import (
 )
 
 // The update_tip workflow. Keeps the tip branch in "sync" with master.
-update_tip: _base.#bashWorkflow & {
+workflows: update_tip: _base.#bashWorkflow & {
 
 	name: "Update tip"
 	on: {

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -39,7 +39,7 @@ workflows: update_tip: _base.#bashWorkflow & {
 		// by repository_dispatch (which will happen if the cue-lang/cue repo
 		// needs to tell us to rebuild tip) only do so if our payload is of
 		// the correct type.
-		if: "${{ github.repository == '\(core.#githubRepositoryPath)' && (github.event_name != 'repository_dispatch' || github.event.client_payload.type == 'rebuild_tip') }}"
+		if: "${{ github.repository == '\(core.githubRepositoryPath)' && (github.event_name != 'repository_dispatch' || github.event.client_payload.type == 'rebuild_tip') }}"
 
 		steps: [
 			_gerrithub.#writeNetrcFile,
@@ -58,7 +58,7 @@ workflows: update_tip: _base.#bashWorkflow & {
 			_#installNetlifyCLI,
 			_#netlifyDeploy & {
 				#prod: true
-				#site: core.#netlifySites.tip
+				#site: core.netlifySites.tip
 				name:  "Deploy tip"
 			},
 			_#cachePost,

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -83,7 +83,7 @@ _#testStrategy: {
 // _gerrithub is an instance of ./gerrithub, parameterised by the properties of
 // this project
 _gerrithub: gerrithub & {
-	#repositoryURL:                      core.#githubRepositoryURL
+	#repositoryURL:                      core.githubRepositoryURL
 	#botGitHubUser:                      "cueckoo"
 	#botGitHubUserTokenSecretsKey:       "CUECKOO_GITHUB_PAT"
 	#botGitHubUserEmail:                 "cueckoo@gmail.com"
@@ -99,7 +99,7 @@ _gerrithub: gerrithub & {
 // Perhaps rename the import to something more obviously not intended to be
 // used, and then rename the field base?
 _base: base & {
-	#repositoryURL:                core.#githubRepositoryURL
+	#repositoryURL:                core.githubRepositoryURL
 	#defaultBranch:                _#defaultBranch
 	#botGitHubUser:                "cueckoo"
 	#botGitHubUserTokenSecretsKey: "CUECKOO_GITHUB_PAT"

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -55,7 +55,12 @@ workflows: close({
 _#defaultBranch:     "master"
 _#releaseTagPattern: "v*"
 
-_#activeBranches: [_#defaultBranch, "alpha"]
+// _#protectedBranchPatterns is a list of glob patterns to match the protected
+// git branches which are continuously used during development on Gerrit.
+// This includes the default branch and release branches,
+// but excludes any others like feature branches or short-lived branches.
+// Note that ci/test is excluded as it is GitHub-only.
+_#protectedBranchPatterns: [_#defaultBranch, "alpha"]
 
 // Use the latest Go version for extra checks,
 // such as running tests with the data race detector.

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -25,31 +25,32 @@ import (
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
-workflows: [...{file: string, schema: (json.#Workflow & {})}]
-workflows: [
-	{
-		// Note: the name of the file corresponds to the environment variable
-		// names for gerritstatusupdater. Therefore, this filename must only be
-		// change in combination with also updating the environment in which
-		// gerritstatusupdater is running for this repository.
-		//
-		// This name is also used by the CI badge in the top-level README.
-		file:   "trybot.yml"
-		schema: trybot
-	},
-	{
-		file:   "trybot_dispatch.yml"
-		schema: trybot_dispatch
-	},
-	{
-		file:   "update_tip.yml"
-		schema: update_tip
-	},
-	{
-		file:   "push_tip_to_trybot.yml"
-		schema: push_tip_to_trybot
-	},
-]
+// Note: the name of the workflows (and hence the corresponding .yml filenames)
+// correspond to the environment variable names for gerritstatusupdater.
+// Therefore, this filename must only be change in combination with also
+// updating the environment in which gerritstatusupdater is running for this
+// repository.
+//
+// This name is also used by the CI badge in the top-level README.
+//
+// This name is also used in the evict_caches lookups.
+//
+// i.e. don't change the names of workflows!
+//
+// In addition to separately declaring the workflows themselves, we define the
+// shape of #workflows here as a cross-check that we don't accidentally change
+// the name of workflows without reading this comment.
+//
+// We explicitly use close() here instead of a definition in order that we can
+// cue export the github package as a test.
+workflows: close({
+	[string]: json.#Workflow
+
+	trybot:             _
+	trybot_dispatch:    _
+	update_tip:         _
+	push_tip_to_trybot: _
+})
 
 _#defaultBranch:     "master"
 _#releaseTagPattern: "v*"

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -52,39 +52,6 @@ workflows: close({
 	push_tip_to_trybot: _
 })
 
-_#defaultBranch:     "master"
-_#releaseTagPattern: "v*"
-
-// _#protectedBranchPatterns is a list of glob patterns to match the protected
-// git branches which are continuously used during development on Gerrit.
-// This includes the default branch and release branches,
-// but excludes any others like feature branches or short-lived branches.
-// Note that ci/test is excluded as it is GitHub-only.
-_#protectedBranchPatterns: [_#defaultBranch, "alpha"]
-
-// Use the latest Go version for extra checks,
-// such as running tests with the data race detector.
-_#latestStableGo: "1.19.x"
-
-_#linuxMachine:   "ubuntu-20.04"
-_#macosMachine:   "macos-11"
-_#windowsMachine: "windows-2022"
-
-// #_isLatestLinux evaluates to true if the job is running on Linux with the
-// latest version of Go. This expression is often used to run certain steps
-// just once per CI workflow, to avoid duplicated work.
-#_isLatestLinux: "matrix.go-version == '\(_#latestStableGo)' && matrix.os == '\(_#linuxMachine)'"
-
-_#goreleaserVersion: "v1.13.1"
-
-_#testStrategy: {
-	"fail-fast": false
-	matrix: {
-		"go-version": ["1.18.x", _#latestStableGo]
-		os: [_#linuxMachine, _#macosMachine, _#windowsMachine]
-	}
-}
-
 // _gerrithub is an instance of ./gerrithub, parameterised by the properties of
 // this project
 _gerrithub: gerrithub & {
@@ -105,7 +72,7 @@ _gerrithub: gerrithub & {
 // used, and then rename the field base?
 _base: base & {
 	#repositoryURL:                core.githubRepositoryURL
-	#defaultBranch:                _#defaultBranch
+	#defaultBranch:                core.defaultBranch
 	#botGitHubUser:                "cueckoo"
 	#botGitHubUserTokenSecretsKey: "CUECKOO_GITHUB_PAT"
 }

--- a/internal/ci/netlify/netlify.cue
+++ b/internal/ci/netlify/netlify.cue
@@ -54,9 +54,9 @@ config: #config & {
 		command:   "bash build.bash"
 		environment: {
 			HUGO_ENV:     "production"
-			GO_VERSION:   core.#goVersion
-			NODE_VERSION: core.#nodeVersion
-			HUGO_VERSION: core.#hugoVersion
+			GO_VERSION:   core.goVersion
+			NODE_VERSION: core.nodeVersion
+			HUGO_VERSION: core.hugoVersion
 		}
 	}
 

--- a/internal/ci/vendor/vendor_tool.cue
+++ b/internal/ci/vendor/vendor_tool.cue
@@ -26,7 +26,7 @@ import (
 // project which "vendors" the various workflow-related
 // packages can specify "cue" as the value so that unity
 // tests can specify the cmd/cue binary to use.
-_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.2" @tag(cue_cmd)
+_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.5" @tag(cue_cmd)
 
 // For the commands below, note we use simple yet hacky path resolution, rather
 // than anything that might derive the module root using go list or similar, in


### PR DESCRIPTION
- internal/ci: move to v0.5.0-beta.5
- internal/ci: use a group of cue commands for go:generate
- internal/ci: refactor the way we declare workflows
- internal/ci: improve core package docs
- internal/ci: move core package away from definitions
- internal/ci: move to concept of protectedBranchPatterns
- internal/ci: move workflows.cue defs to better places
- internal/ci: baseline base and gerrithub against main CUE repo
