### PR TITLE
trybot/Ic84a0802f88d72c26bc0a67bd45dbd1c69dc96af/fcd8c771eebd6db1b482d021554d349bb0cd25d3/551432/1

### DIFF
--- a/.github/workflows/push_tip_to_trybot.yml
+++ b/.github/workflows/push_tip_to_trybot.yml
@@ -33,5 +33,5 @@ jobs:
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n cueckoo:${{ secrets.CUECKOO_GITHUB_PAT }} | base64)"
           git remote add origin https://review.gerrithub.io/a/cue-lang/cuelang.org
           git remote add trybot https://github.com/cue-lang/cuelang.org-trybot
-          git fetch origin master alpha
-          git push trybot "refs/remotes/origin/*:refs/heads/*"
+          git fetch origin "${{ github.ref }}"
+          git push trybot "FETCH_HEAD:${{ github.ref }}"

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -4,9 +4,9 @@ name: TryBot
 "on":
   push:
     branches:
+      - ci/test
       - master
       - alpha
-      - ci/test
   pull_request: {}
 jobs:
   test:

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -40,12 +40,13 @@ _goos: string @tag(os,var=os)
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
 command: gen: workflows: {
-	for w in github.workflows {
-		"\(w.file)": file.Create & {
+	for _workflowName, _workflow in github.workflows {
+		let _filename = _workflowName + ".yml"
+		(_filename): file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
-			filename: path.Join([_dir, w.file], _goos)
+			filename: path.Join([_dir, _filename], _goos)
 			let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
-			contents: "# \(donotedit)\n\n\(yaml.Marshal(w.schema))"
+			contents: "# \(donotedit)\n\n\(yaml.Marshal(_workflow))"
 		}
 	}
 }

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -22,7 +22,7 @@ import (
 	"github.com/cue-lang/cuelang.org/internal/ci/base"
 	"github.com/cue-lang/cuelang.org/internal/ci/core"
 	"github.com/cue-lang/cuelang.org/internal/ci/github"
-	"github.com/cue-lang/cuelang.org/internal/ci/netlify"
+	_netlify "github.com/cue-lang/cuelang.org/internal/ci/netlify"
 )
 
 // For the commands below, note we use simple yet hacky path resolution, rather
@@ -34,13 +34,12 @@ import (
 
 _goos: string @tag(os,var=os)
 
-// genworkflows regenerates the GitHub workflow Yaml definitions.
+// gen.workflows regenerates the GitHub workflow Yaml definitions.
 //
 // See internal/ci/gen.go for details on how this step fits into the sequence
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
-command: genworkflows: {
-
+command: gen: workflows: {
 	for w in github.workflows {
 		"\(w.file)": file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
@@ -51,10 +50,10 @@ command: genworkflows: {
 	}
 }
 
-command: gennetlify: file.Create & {
+command: gen: netlify: file.Create & {
 	_dir:     path.FromSlash("../../", path.Unix)
 	filename: path.Join([_dir, "netlify.toml"], _goos)
-	let res = netlify.#toToml & {#input: netlify.config, _}
+	let res = _netlify.#toToml & {#input: _netlify.config, _}
 	let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
 	contents: "# \(donotedit)\n\n\(res)\n"
 }

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -1,3 +1,6 @@
+// package core contains data values that are commont to all CUE
+// configurations.  This not only includes GitHub workflows, but also things
+// like gerrit configuration etc.
 package core
 
 import (

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -9,9 +9,9 @@ import (
 )
 
 // Define core URLs that will be used in the codereview.cfg and GitHub workflows
-#githubRepositoryURL:  "https://github.com/cue-lang/cuelang.org"
-#gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cuelang.org"
-#githubRepositoryPath: _#URLPath & {#url: #githubRepositoryURL, _}
+githubRepositoryURL:  "https://github.com/cue-lang/cuelang.org"
+gerritRepositoryURL:  "https://review.gerrithub.io/a/cue-lang/cuelang.org"
+githubRepositoryPath: _#URLPath & {#url: githubRepositoryURL, _}
 
 // Not ideal, but hack together something that gives us the path
 // of a URL. In lieu of cuelang.org/issue/1433
@@ -24,20 +24,20 @@ _#URLPath: {
 // Use a specific latest version for release builds.
 // Note that we don't want ".x" for the sake of reproducibility,
 // so we instead pin a specific Go release.
-#goVersion: "1.19.3"
+goVersion: "1.19.3"
 
 // Use a specific version of NodeJS for deploy purposes. This version
 // is consistent between netlify and GitHub Actions usage.
-#nodeVersion: "18.8.0"
+nodeVersion: "18.8.0"
 
 // hugoVersion is the version of hugo used in generating our static site
-#hugoVersion: "0.89.4"
+hugoVersion: "0.89.4"
 
 // netlifyCLIVersion is the version of the Netlify CLI used to deploy tip and
 // deploy previews of CLs
-#netlifyCLIVersion: "12.4.0"
+netlifyCLIVersion: "12.4.0"
 
-#netlifySites: {
+netlifySites: {
 	cls: "cue-cls"
 	tip: "cue-tip"
 }
@@ -49,8 +49,8 @@ _#URLPath: {
 }
 
 codeReview: #codeReview & {
-	github: #githubRepositoryURL
-	gerrit: #gerritRepositoryURL
+	github: githubRepositoryURL
+	gerrit: gerritRepositoryURL
 }
 
 // #toCodeReviewCfg converts a #codeReview instance to

--- a/internal/ci/gen.go
+++ b/internal/ci/gen.go
@@ -14,7 +14,7 @@
 
 package ci
 
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd importjsonschema ./vendor
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd genworkflows
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd gennetlify
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd gencodereviewcfg
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd importjsonschema ./vendor
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd genworkflows
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gennetlify
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gencodereviewcfg

--- a/internal/ci/gen.go
+++ b/internal/ci/gen.go
@@ -15,6 +15,4 @@
 package ci
 
 //go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd importjsonschema ./vendor
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd genworkflows
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gennetlify
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gencodereviewcfg
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gen

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -34,7 +34,7 @@ workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	jobs: push: {
 		"runs-on": _#linuxMachine
-		if:        "${{github.repository == '\(core.#githubRepositoryPath)'}}"
+		if:        "${{github.repository == '\(core.githubRepositoryPath)'}}"
 		steps: [
 			_gerrithub.#writeNetrcFile,
 			json.#step & {

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -15,19 +15,19 @@
 package github
 
 import (
-	"strings"
-
 	"github.com/cue-lang/cuelang.org/internal/ci/core"
 
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
-// push_tip_to_trybot "syncs" active branches to the trybot repo
+// push_tip_to_trybot "syncs" active branches to the trybot repo.
+// Since the workflow is triggered by a push to any of the branches,
+// the step only needs to sync the pushed branch.
 workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {
-		push: branches: _#activeBranches
+		push: branches: _#protectedBranchPatterns
 	}
 
 	concurrency: "push_tip_to_trybot"
@@ -48,8 +48,8 @@ workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 						git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n \(_gerrithub.#botGitHubUser):${{ secrets.\(_gerrithub.#botGitHubUserTokenSecretsKey) }} | base64)"
 						git remote add origin \(_gerrithub.#gerritHubRepository)
 						git remote add trybot \(_gerrithub.#trybotRepositoryURL)
-						git fetch origin \(strings.Join(_#activeBranches, " "))
-						git push trybot "refs/remotes/origin/*:refs/heads/*"
+						git fetch origin "${{ github.ref }}"
+						git push trybot "FETCH_HEAD:${{ github.ref }}"
 						"""
 			},
 		]

--- a/internal/ci/github/push_tip_to_trybot.cue
+++ b/internal/ci/github/push_tip_to_trybot.cue
@@ -23,7 +23,7 @@ import (
 )
 
 // push_tip_to_trybot "syncs" active branches to the trybot repo
-push_tip_to_trybot: _base.#bashWorkflow & {
+workflows: push_tip_to_trybot: _base.#bashWorkflow & {
 
 	name: "Push tip to trybot"
 	on: {

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -25,7 +25,7 @@ import (
 )
 
 // The trybot workflow.
-trybot: _base.#bashWorkflow & {
+workflows: trybot: _base.#bashWorkflow & {
 	// Note: the name of this workflow is used by gerritstatusupdater as an
 	// identifier in the status updates that are posted as reviews for this
 	// workflows, but also as the result label key, e.g. "TryBot-Result" would

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -122,7 +122,7 @@ workflows: trybot: _base.#bashWorkflow & {
 				//     trybot/I01e0e139902da54151659fe595f23dd519f54637/2e79979116f96a26c9240e0e9c55b31d4311cf93/547774/11
 				//
 				json.#step & {
-					if: "${{github.repository == '\(core.#githubRepositoryPath)-trybot' && startsWith(github.head_ref, 'trybot/')}}"
+					if: "${{github.repository == '\(core.githubRepositoryPath)-trybot' && startsWith(github.head_ref, 'trybot/')}}"
 					id: "alias"
 
 					// Use github.head_ref per
@@ -138,8 +138,8 @@ workflows: trybot: _base.#bashWorkflow & {
 				// Only run a deploy of tip if we are running as part of the trybot repo,
 				// with a branch name that matches the trybot pattern
 				_#netlifyDeploy & {
-					if:     "${{github.repository == '\(core.#githubRepositoryPath)-trybot' && startsWith(github.head_ref, 'trybot/')}}"
-					#site:  core.#netlifySites.cls
+					if:     "${{github.repository == '\(core.githubRepositoryPath)-trybot' && startsWith(github.head_ref, 'trybot/')}}"
+					#site:  core.netlifySites.cls
 					#alias: "${{ steps.alias.outputs.alias }}"
 					name:   "Deploy preview of CL"
 				},
@@ -173,19 +173,19 @@ _#installNode: json.#step & {
 	name: "Install Node"
 	uses: "actions/setup-node@v3"
 	with: {
-		"node-version": core.#nodeVersion
+		"node-version": core.nodeVersion
 	}
 }
 
 _#installGo: _base.#installGo & {
-	with: "go-version": core.#goVersion
+	with: "go-version": core.goVersion
 }
 
 _#installHugo: json.#step & {
 	name: "Install Hugo"
 	uses: "peaceiris/actions-hugo@v2"
 	with: {
-		"hugo-version": core.#hugoVersion
+		"hugo-version": core.hugoVersion
 		extended:       true
 	}
 }
@@ -202,7 +202,7 @@ _#tipDist: _#dist & {
 
 _#installNetlifyCLI: json.#step & {
 	name: "Install Netlify CLI"
-	run:  "npm install -g netlify-cli@\(core.#netlifyCLIVersion)"
+	run:  "npm install -g netlify-cli@\(core.netlifyCLIVersion)"
 }
 
 // _#netlifyDeploy is used to push CLs for preview but also to deploy tip

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -15,6 +15,7 @@
 package github
 
 import (
+	"list"
 	"strings"
 	"strconv"
 
@@ -37,7 +38,7 @@ workflows: trybot: _base.#bashWorkflow & {
 
 	on: {
 		push: {
-			branches: [ for v in _#activeBranches {v}, _base.#testDefaultBranch]
+			branches: list.Concat([[_base.#testDefaultBranch], _#protectedBranchPatterns])
 		}
 		pull_request: {}
 	}

--- a/internal/ci/github/trybot_dispatch.cue
+++ b/internal/ci/github/trybot_dispatch.cue
@@ -15,6 +15,6 @@
 package github
 
 // The trybot_dispatch workflow.
-trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
+workflows: trybot_dispatch: _base.#bashWorkflow & _gerrithub.#dispatchWorkflow & {
 	#type: _gerrithub.#dispatchTrybot
 }

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -19,7 +19,7 @@ import (
 )
 
 // The update_tip workflow. Keeps the tip branch in "sync" with master.
-update_tip: _base.#bashWorkflow & {
+workflows: update_tip: _base.#bashWorkflow & {
 
 	name: "Update tip"
 	on: {

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -39,7 +39,7 @@ workflows: update_tip: _base.#bashWorkflow & {
 		// by repository_dispatch (which will happen if the cue-lang/cue repo
 		// needs to tell us to rebuild tip) only do so if our payload is of
 		// the correct type.
-		if: "${{ github.repository == '\(core.#githubRepositoryPath)' && (github.event_name != 'repository_dispatch' || github.event.client_payload.type == 'rebuild_tip') }}"
+		if: "${{ github.repository == '\(core.githubRepositoryPath)' && (github.event_name != 'repository_dispatch' || github.event.client_payload.type == 'rebuild_tip') }}"
 
 		steps: [
 			_gerrithub.#writeNetrcFile,
@@ -58,7 +58,7 @@ workflows: update_tip: _base.#bashWorkflow & {
 			_#installNetlifyCLI,
 			_#netlifyDeploy & {
 				#prod: true
-				#site: core.#netlifySites.tip
+				#site: core.netlifySites.tip
 				name:  "Deploy tip"
 			},
 			_#cachePost,

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -83,7 +83,7 @@ _#testStrategy: {
 // _gerrithub is an instance of ./gerrithub, parameterised by the properties of
 // this project
 _gerrithub: gerrithub & {
-	#repositoryURL:                      core.#githubRepositoryURL
+	#repositoryURL:                      core.githubRepositoryURL
 	#botGitHubUser:                      "cueckoo"
 	#botGitHubUserTokenSecretsKey:       "CUECKOO_GITHUB_PAT"
 	#botGitHubUserEmail:                 "cueckoo@gmail.com"
@@ -99,7 +99,7 @@ _gerrithub: gerrithub & {
 // Perhaps rename the import to something more obviously not intended to be
 // used, and then rename the field base?
 _base: base & {
-	#repositoryURL:                core.#githubRepositoryURL
+	#repositoryURL:                core.githubRepositoryURL
 	#defaultBranch:                _#defaultBranch
 	#botGitHubUser:                "cueckoo"
 	#botGitHubUserTokenSecretsKey: "CUECKOO_GITHUB_PAT"

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -55,7 +55,12 @@ workflows: close({
 _#defaultBranch:     "master"
 _#releaseTagPattern: "v*"
 
-_#activeBranches: [_#defaultBranch, "alpha"]
+// _#protectedBranchPatterns is a list of glob patterns to match the protected
+// git branches which are continuously used during development on Gerrit.
+// This includes the default branch and release branches,
+// but excludes any others like feature branches or short-lived branches.
+// Note that ci/test is excluded as it is GitHub-only.
+_#protectedBranchPatterns: [_#defaultBranch, "alpha"]
 
 // Use the latest Go version for extra checks,
 // such as running tests with the data race detector.

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -25,31 +25,32 @@ import (
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
 
-workflows: [...{file: string, schema: (json.#Workflow & {})}]
-workflows: [
-	{
-		// Note: the name of the file corresponds to the environment variable
-		// names for gerritstatusupdater. Therefore, this filename must only be
-		// change in combination with also updating the environment in which
-		// gerritstatusupdater is running for this repository.
-		//
-		// This name is also used by the CI badge in the top-level README.
-		file:   "trybot.yml"
-		schema: trybot
-	},
-	{
-		file:   "trybot_dispatch.yml"
-		schema: trybot_dispatch
-	},
-	{
-		file:   "update_tip.yml"
-		schema: update_tip
-	},
-	{
-		file:   "push_tip_to_trybot.yml"
-		schema: push_tip_to_trybot
-	},
-]
+// Note: the name of the workflows (and hence the corresponding .yml filenames)
+// correspond to the environment variable names for gerritstatusupdater.
+// Therefore, this filename must only be change in combination with also
+// updating the environment in which gerritstatusupdater is running for this
+// repository.
+//
+// This name is also used by the CI badge in the top-level README.
+//
+// This name is also used in the evict_caches lookups.
+//
+// i.e. don't change the names of workflows!
+//
+// In addition to separately declaring the workflows themselves, we define the
+// shape of #workflows here as a cross-check that we don't accidentally change
+// the name of workflows without reading this comment.
+//
+// We explicitly use close() here instead of a definition in order that we can
+// cue export the github package as a test.
+workflows: close({
+	[string]: json.#Workflow
+
+	trybot:             _
+	trybot_dispatch:    _
+	update_tip:         _
+	push_tip_to_trybot: _
+})
 
 _#defaultBranch:     "master"
 _#releaseTagPattern: "v*"

--- a/internal/ci/netlify/netlify.cue
+++ b/internal/ci/netlify/netlify.cue
@@ -54,9 +54,9 @@ config: #config & {
 		command:   "bash build.bash"
 		environment: {
 			HUGO_ENV:     "production"
-			GO_VERSION:   core.#goVersion
-			NODE_VERSION: core.#nodeVersion
-			HUGO_VERSION: core.#hugoVersion
+			GO_VERSION:   core.goVersion
+			NODE_VERSION: core.nodeVersion
+			HUGO_VERSION: core.hugoVersion
 		}
 	}
 

--- a/internal/ci/vendor/vendor_tool.cue
+++ b/internal/ci/vendor/vendor_tool.cue
@@ -26,7 +26,7 @@ import (
 // project which "vendors" the various workflow-related
 // packages can specify "cue" as the value so that unity
 // tests can specify the cmd/cue binary to use.
-_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.2" @tag(cue_cmd)
+_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.5" @tag(cue_cmd)
 
 // For the commands below, note we use simple yet hacky path resolution, rather
 // than anything that might derive the module root using go list or similar, in


### PR DESCRIPTION
- internal/ci: move to v0.5.0-beta.5
- internal/ci: use a group of cue commands for go:generate
- internal/ci: refactor the way we declare workflows
- internal/ci: improve core package docs
- internal/ci: move core package away from definitions
- internal/ci: move to concept of protectedBranchPatterns
