### PR TITLE
trybot/I2fdeaae47fb82e44deb8cb84a368802bb17413ee/df61b7eff08c4eb152df5f2d30926013475a3da8/551428/1

### DIFF
--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -22,7 +22,7 @@ import (
 	"github.com/cue-lang/cuelang.org/internal/ci/base"
 	"github.com/cue-lang/cuelang.org/internal/ci/core"
 	"github.com/cue-lang/cuelang.org/internal/ci/github"
-	"github.com/cue-lang/cuelang.org/internal/ci/netlify"
+	_netlify "github.com/cue-lang/cuelang.org/internal/ci/netlify"
 )
 
 // For the commands below, note we use simple yet hacky path resolution, rather
@@ -34,13 +34,12 @@ import (
 
 _goos: string @tag(os,var=os)
 
-// genworkflows regenerates the GitHub workflow Yaml definitions.
+// gen.workflows regenerates the GitHub workflow Yaml definitions.
 //
 // See internal/ci/gen.go for details on how this step fits into the sequence
 // of generating our CI workflow definitions, and updating various txtar tests
 // with files from that process.
-command: genworkflows: {
-
+command: gen: workflows: {
 	for w in github.workflows {
 		"\(w.file)": file.Create & {
 			_dir:     path.FromSlash("../../.github/workflows", path.Unix)
@@ -51,10 +50,10 @@ command: genworkflows: {
 	}
 }
 
-command: gennetlify: file.Create & {
+command: gen: netlify: file.Create & {
 	_dir:     path.FromSlash("../../", path.Unix)
 	filename: path.Join([_dir, "netlify.toml"], _goos)
-	let res = netlify.#toToml & {#input: netlify.config, _}
+	let res = _netlify.#toToml & {#input: _netlify.config, _}
 	let donotedit = base.#doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
 	contents: "# \(donotedit)\n\n\(res)\n"
 }

--- a/internal/ci/gen.go
+++ b/internal/ci/gen.go
@@ -14,7 +14,7 @@
 
 package ci
 
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd importjsonschema ./vendor
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd genworkflows
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd gennetlify
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.2 cmd gencodereviewcfg
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd importjsonschema ./vendor
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd genworkflows
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gennetlify
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gencodereviewcfg

--- a/internal/ci/gen.go
+++ b/internal/ci/gen.go
@@ -15,6 +15,4 @@
 package ci
 
 //go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd importjsonschema ./vendor
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd genworkflows
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gennetlify
-//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gencodereviewcfg
+//go:generate go run cuelang.org/go/cmd/cue@v0.5.0-beta.5 cmd gen

--- a/internal/ci/vendor/vendor_tool.cue
+++ b/internal/ci/vendor/vendor_tool.cue
@@ -26,7 +26,7 @@ import (
 // project which "vendors" the various workflow-related
 // packages can specify "cue" as the value so that unity
 // tests can specify the cmd/cue binary to use.
-_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.2" @tag(cue_cmd)
+_cueCmd: string | *"go run cuelang.org/go/cmd/cue@v0.5.0-beta.5" @tag(cue_cmd)
 
 // For the commands below, note we use simple yet hacky path resolution, rather
 // than anything that might derive the module root using go list or similar, in


### PR DESCRIPTION
- internal/ci: move to v0.5.0-beta.5
- internal/ci: use a group of cue commands for go:generate
