### PR TITLE
internal/ci: make Go, Node and Hugo versions consistent with alpha

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -22,15 +22,15 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.8.0
+          node-version: 18.12.1
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 0.89.4
+          hugo-version: 0.108.0
           extended: true
       - id: npm-cache-dir
         name: Get npm cache directory

--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -30,15 +30,15 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.8.0
+          node-version: 18.12.1
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 0.89.4
+          hugo-version: 0.108.0
           extended: true
       - id: npm-cache-dir
         name: Get npm cache directory

--- a/internal/ci/core/core.cue
+++ b/internal/ci/core/core.cue
@@ -21,14 +21,14 @@ _#URLPath: {
 // Use a specific latest version for release builds.
 // Note that we don't want ".x" for the sake of reproducibility,
 // so we instead pin a specific Go release.
-#goVersion: "1.19.3"
+#goVersion: "1.19.4"
 
 // Use a specific version of NodeJS for deploy purposes. This version
 // is consistent between netlify and GitHub Actions usage.
-#nodeVersion: "18.8.0"
+#nodeVersion: "18.12.1"
 
 // hugoVersion is the version of hugo used in generating our static site
-#hugoVersion: "0.89.4"
+#hugoVersion: "0.108.0"
 
 // netlifyCLIVersion is the version of the Netlify CLI used to deploy tip and
 // deploy previews of CLs

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,10 @@
   command = "bash build.bash"
 
 [build.environment]
-GO_VERSION = "1.19.3"
+GO_VERSION = "1.19.4"
 HUGO_ENV = "production"
-HUGO_VERSION = "0.89.4"
-NODE_VERSION = "18.8.0"
+HUGO_VERSION = "0.108.0"
+NODE_VERSION = "18.12.1"
 
 [context.deploy-preview]
 command = "bash build.bash -b $DEPLOY_URL"


### PR DESCRIPTION
This makes applying changes from the default branch, changes related to
the trybot refactors, to the alpha branch cleaner.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I5e83429ecd1f94c322709f13d30398921d9fee4b
