### PR TITLE
trybot/If69f8f168292746b8f570a04fc6f3b99c5267e8a/8558123c46454a29fa7a0156cbadb4d7bda6ac87/551476/2

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -19,6 +19,59 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Early git and code sanity checks
+        run: |-
+          # Ensure the recent commit messages have Signed-off-by headers.
+          # TODO: Remove once this is enforced for admins too;
+          # see https://bugs.chromium.org/p/gerrit/issues/detail?id=15229
+          # TODO: Our --max-count here is just 1, because we've made mistakes very
+          # recently. Increase it to 5 or 10 soon, to also cover CL chains.
+          for commit in $(git rev-list --max-count=1 HEAD); do
+          	if ! git rev-list --format=%B --max-count=1 $commit | grep -q '^Signed-off-by:'; then
+          		echo -e "\nRecent commit is lacking Signed-off-by:\n"
+          		git show --quiet $commit
+          		exit 1
+          	fi
+          done
+
+          # Ensure that commit messages have a blank second line.
+          # We know that a commit message must be longer than a single
+          # line because each commit must be signed-off.
+          if git log --format=%B -n 1 HEAD | sed -n '2{/^$/{q1}}'; then
+          	echo "second line of commit message must be blank"
+          	exit 1
+          fi
+
+          # Ensure that the commit author is the same as the signed-off-by.  This
+          # is a basic requirement of DCO. It is enforced by Gerrit (although
+          # noting that in Gerrit the author name does not have to match, only
+          # the email address), but _not_ by the DCO GitHub app:
+          #
+          #   https://github.com/dcoapp/app/issues/201
+          #
+          # Provide a sanity check as part of GitHub workflows that should enforce
+          # this, e.g. trybot workflows.
+          #
+          # We do so by comparing the commit author and "Signed-off-by" trailer for
+          # strict equality. Whilst this is more strict than Gerrit, it should
+          # generally be the case, and we can always relax this when presented with
+          # specific situations where it is is a problem.
+
+          # commit author email address
+          commitauthor="$(git log -1 --pretty="%ae")"
+
+          # signed-off-by trailer email address. There is no way to parse just the
+          # email address from the trailer in the same way as git log, so instead
+          # grab the relevant trailer and then take the last whitespace-delimited
+          # part as the "<>" contained email address.
+          # Getting the Signed-off-by trailer in this way causes blank
+          # lines for some reason. Use awk to remove them.
+          commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | sed -ne 's/.* <\(.*\)>/\1/p')"
+
+          if [[ "$commitauthor" != "$commitsigner" ]]; then
+          	echo "commit author email address does not match signed-off-by trailer"
+          	exit 1
+          fi
       - name: Install Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: ./play
       - name: Dist
         run: ./build.bash
-      - name: Verify commit is clean
+      - name: Check that git is clean at the end of the job
         run: test -z "$(git status --porcelain)" || (git status; git diff; false)
       - id: alias
         if: ${{github.repository == 'cue-lang/cuelang.org-trybot' && startsWith(github.head_ref, 'trybot/')}}

--- a/internal/ci/base/base.cue
+++ b/internal/ci/base/base.cue
@@ -62,7 +62,7 @@ import (
 
 #earlyChecks: json.#step & {
 	name: "Early git and code sanity checks"
-	run: """
+	run: #"""
 		# Ensure the recent commit messages have Signed-off-by headers.
 		# TODO: Remove once this is enforced for admins too;
 		# see https://bugs.chromium.org/p/gerrit/issues/detail?id=15229
@@ -75,7 +75,46 @@ import (
 				exit 1
 			fi
 		done
-		"""
+
+		# Ensure that commit messages have a blank second line.
+		# We know that a commit message must be longer than a single
+		# line because each commit must be signed-off.
+		if git log --format=%B -n 1 HEAD | sed -n '2{/^$/{q1}}'; then
+			echo "second line of commit message must be blank"
+			exit 1
+		fi
+
+		# Ensure that the commit author is the same as the signed-off-by.  This
+		# is a basic requirement of DCO. It is enforced by Gerrit (although
+		# noting that in Gerrit the author name does not have to match, only
+		# the email address), but _not_ by the DCO GitHub app:
+		#
+		#   https://github.com/dcoapp/app/issues/201
+		#
+		# Provide a sanity check as part of GitHub workflows that should enforce
+		# this, e.g. trybot workflows.
+		#
+		# We do so by comparing the commit author and "Signed-off-by" trailer for
+		# strict equality. Whilst this is more strict than Gerrit, it should
+		# generally be the case, and we can always relax this when presented with
+		# specific situations where it is is a problem.
+
+		# commit author email address
+		commitauthor="$(git log -1 --pretty="%ae")"
+
+		# signed-off-by trailer email address. There is no way to parse just the
+		# email address from the trailer in the same way as git log, so instead
+		# grab the relevant trailer and then take the last whitespace-delimited
+		# part as the "<>" contained email address.
+		# Getting the Signed-off-by trailer in this way causes blank
+		# lines for some reason. Use awk to remove them.
+		commitsigner="$(git log -1 --pretty='%(trailers:key=Signed-off-by,valueonly)' | sed -ne 's/.* <\(.*\)>/\1/p')"
+
+		if [[ "$commitauthor" != "$commitsigner" ]]; then
+			echo "commit author email address does not match signed-off-by trailer"
+			exit 1
+		fi
+		"""#
 }
 
 #cacheGoModules: json.#step & {

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -21,6 +21,7 @@ import (
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 
 	"github.com/cue-lang/cuelang.org/internal/ci/core"
+	"github.com/cue-lang/cuelang.org/internal/ci/base"
 	"github.com/cue-lang/cuelang.org/internal/ci/netlify"
 )
 
@@ -53,6 +54,10 @@ trybot: _base.#bashWorkflow & {
 					// This doesn't affect "push" builds, which never used merge commits.
 					with: ref: "${{ github.event.pull_request.head.sha }}"
 				},
+
+				// Early git checks
+				base.#earlyChecks,
+
 				_#installNode,
 				_#installGo,
 				_#installHugo,

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -105,13 +105,7 @@ trybot: _base.#bashWorkflow & {
 				},
 
 				_#dist,
-
-				json.#step & {
-					name: "Verify commit is clean"
-					run: """
-						test -z "$(git status --porcelain)" || (git status; git diff; false)
-						"""
-				},
+				_base.#checkGitClean,
 
 				// GitHub offers very limited expressions at runtime of a workflow.
 				// Instead we have to resort to dropping down to shell and then

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -71,14 +71,6 @@ _#windowsMachine: "windows-2022"
 
 _#goreleaserVersion: "v1.13.1"
 
-_#testStrategy: {
-	"fail-fast": false
-	matrix: {
-		"go-version": ["1.18.x", _#latestStableGo]
-		os: [_#linuxMachine, _#macosMachine, _#windowsMachine]
-	}
-}
-
 // _gerrithub is an instance of ./gerrithub, parameterised by the properties of
 // this project
 _gerrithub: gerrithub & {


### PR DESCRIPTION
- internal/ci: use base definition to check for porcelain commit
- internal/ci: adopt early git checks from alpha
- internal/ci: remove unused definition
