### PR TITLE
internal/ci: make update_tip consistent with master

### DIFF
--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -5,6 +5,7 @@ name: Update tip
   push:
     branches:
       - master
+  repository_dispatch: {}
 concurrency: deploy
 jobs:
   push:
@@ -12,7 +13,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    if: ${{github.repository == 'cue-lang/cuelang.org'}}
+    if: ${{ github.repository == 'cue-lang/cuelang.org' && (github.event_name != 'repository_dispatch' || github.event.client_payload.type == 'rebuild_tip') }}
     steps:
       - name: Write netrc file for cueckoo Gerrithub
         run: |-


### PR DESCRIPTION
Whilst this doesn't have any effect for the alpha branch (because
repository_dispatch only ever runs for default branch workflows) it
makes applying the sequence of commits for the trybot refactor from the
default branch cleaner.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I5227a8ecae89c49b48554ac1c1e8140d6ecd3b80
