### PR TITLE
internal/ci: baseline base against cef63a35 from main CUE repo

### DIFF
--- a/.github/workflows/evict_caches.yml
+++ b/.github/workflows/evict_caches.yml
@@ -1,0 +1,51 @@
+# Code generated internal/ci/ci_tool.cue; DO NOT EDIT.
+
+name: Evict caches
+"on":
+  schedule:
+    - cron: 0 2 * * *
+jobs:
+  test:
+    if: ${{github.repository == 'cue-lang/cuelang.org'}}
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - run: |-
+          set -eux
+
+          echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
+          gh extension install actions/gh-actions-cache
+          for i in https://github.com/cue-lang/cuelang.org https://github.com/cue-lang/cuelang.org-trybot
+          do
+          	echo "Evicting caches for $i"
+          	cd $(mktemp -d)
+          	git init
+          	git remote add origin $i
+          	for j in $(gh actions-cache list -L 100 | grep refs/ | awk '{print $1}')
+          	do
+          		gh actions-cache delete --confirm $j
+          	done
+          done
+
+          # Now trigger the most recent workflow run on each of the default branches.
+          # We do this by listing all the branches on the main repo and finding those
+          # which match the protected branch patterns (globs).
+          for j in $(curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" -f https://api.github.com/repos/cue-lang/cuelang.org/branches | jq -r '.[] | .name')
+          do
+          	for i in master alpha
+          	do
+          		if [[ "$j" != $i ]]; then
+          			continue
+          		fi
+
+          		echo "$j is a match with $i"
+          		id=$(curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/cue-lang/cuelang.org/actions/workflows/trybot.yml/runs?branch=$j&event=push&per_page=1" | jq '.workflow_runs[] | .id')
+          curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" -X POST https://api.github.com/repos/cue-lang/cuelang.org/actions/runs/$id/rerun
+
+          		id=$(curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/cue-lang/cuelang.org-trybot/actions/workflows/trybot.yml/runs?branch=$j&event=push&per_page=1" | jq '.workflow_runs[] | .id')
+          curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.CUECKOO_GITHUB_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" -X POST https://api.github.com/repos/cue-lang/cuelang.org-trybot/actions/runs/$id/rerun
+
+          	done
+          done

--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -4,7 +4,6 @@ name: TryBot
 "on":
   push:
     branches:
-      - trybot/*/*
       - ci/test
       - master
       - alpha
@@ -106,16 +105,16 @@ jobs:
           path: |-
             ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
             ${{ steps.go-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
+          key: Linux-1.20.2-${{ github.run_id }}
+          restore-keys: Linux-1.20.2
       - if: '! (github.ref == ''refs/heads/master'' || github.ref == ''refs/heads/alpha'')'
         uses: actions/cache/restore@v3
         with:
           path: |-
             ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
             ${{ steps.go-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
+          key: Linux-1.20.2-${{ github.run_id }}
+          restore-keys: Linux-1.20.2
       - if: github.repository == 'cue-lang/cuelang.org' && ((github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha') || github.ref == 'refs/heads/ci/test')
         run: go clean -testcache
       - name: Ensure latest CUE

--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -44,22 +44,13 @@ jobs:
       - id: go-cache-dir
         name: Get go build/test cache directory
         run: echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
-      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha')
-        uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         with:
           path: |-
             ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
             ${{ steps.go-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
-      - if: '! (github.ref == ''refs/heads/master'' || github.ref == ''refs/heads/alpha'')'
-        uses: actions/cache/restore@v3
-        with:
-          path: |-
-            ${{ steps.go-mod-cache-dir.outputs.dir }}/cache/download
-            ${{ steps.go-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-${{ matrix.go-version }}
+          key: Linux-1.20.2-${{ github.run_id }}
+          restore-keys: Linux-1.20.2
       - name: Tip dist
         run: ./build.bash
         env:

--- a/internal/ci/base/gerrithub.cue
+++ b/internal/ci/base/gerrithub.cue
@@ -3,8 +3,18 @@ package base
 // This file contains gerrithub related definitions etc
 
 import (
+	"strings"
+
 	"github.com/SchemaStore/schemastore/src/schemas/json"
 )
+
+// trybotWorkflows is a template for trybot-based repos
+trybotWorkflows: {
+	(trybot.key):                json.#Workflow
+	"\(trybot.key)_dispatch":    trybotDispatchWorkflow
+	"push_tip_to_\(trybot.key)": pushTipToTrybotWorkflow
+	"evict_caches":              evictCaches
+}
 
 trybotDispatchWorkflow: bashWorkflow & {
 	_#branchNameExpression: "\(trybot.key)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}/${{ steps.gerrithub_ref.outputs.gerrithub_ref }}"
@@ -99,6 +109,99 @@ pushTipToTrybotWorkflow: bashWorkflow & {
 		]
 	}
 
+}
+
+// evictCaches removes "old" GitHub actions caches from the main repo and the
+// accompanying trybot  The job is only run in the main repo, because
+// that is the only place where the credentials exist.
+//
+// The GitHub actions caches in the main and trybot repos can get large. So
+// large in fact we got the following warning from GitHub:
+//
+//   "Approaching total cache storage limit (34.5 GB of 10 GB Used)"
+//
+// Yes, you did read that right.
+//
+// Not only does this have the effect of causing us to breach "limits" it also
+// means that we can't be sure that individual caches are not bloated.
+//
+// Fix that by purging the actions caches on a daily basis at 0200, followed 15
+// mins later by a re-run of the tip trybots to repopulate the caches so they
+// are warm and minimal.
+//
+// In testing with @mvdan, this resulted in cache sizes for Linux dropping from
+// ~1GB to ~125MB. This is a considerable saving.
+//
+// Note this currently removes all cache entries, regardless of whether they
+// are go-related or not. We should revisit this later.
+evictCaches: bashWorkflow & {
+	name: "Evict caches"
+
+	on: {
+		schedule: [
+			{cron: "0 2 * * *"},
+		]
+	}
+
+	jobs: {
+		test: {
+			// We only want to run this in the main repo
+			if:        "${{github.repository == '\(githubRepositoryPath)'}}"
+			"runs-on": linuxMachine
+			steps: [
+				json.#step & {
+					let branchPatterns = strings.Join(protectedBranchPatterns, " ")
+
+					// rerunLatestWorkflow runs the latest trybot workflow in the
+					// specified repo for branches that match the specified branch.
+					let rerunLatestWorkflow = {
+						#repo:   string
+						#branch: string
+						"""
+						id=$(\(curlGitHubAPI) "https://api.github.com/repos/\(#repo)/actions/workflows/\(trybot.key).yml/runs?branch=\(#branch)&event=push&per_page=1" | jq '.workflow_runs[] | .id')
+						\(curlGitHubAPI) -X POST https://api.github.com/repos/\(#repo)/actions/runs/$id/rerun
+
+						"""
+					}
+
+					run: """
+						set -eux
+
+						echo ${{ secrets.CUECKOO_GITHUB_PAT }} | gh auth login --with-token
+						gh extension install actions/gh-actions-cache
+						for i in \(githubRepositoryURL) \(trybotRepositoryURL)
+						do
+							echo "Evicting caches for $i"
+							cd $(mktemp -d)
+							git init
+							git remote add origin $i
+							for j in $(gh actions-cache list -L 100 | grep refs/ | awk '{print $1}')
+							do
+								gh actions-cache delete --confirm $j
+							done
+						done
+
+						# Now trigger the most recent workflow run on each of the default branches.
+						# We do this by listing all the branches on the main repo and finding those
+						# which match the protected branch patterns (globs).
+						for j in $(\(curlGitHubAPI) -f https://api.github.com/repos/\(githubRepositoryPath)/branches | jq -r '.[] | .name')
+						do
+							for i in \(branchPatterns)
+							do
+								if [[ "$j" != $i ]]; then
+									continue
+								fi
+
+								echo "$j is a match with $i"
+								\(rerunLatestWorkflow & {#repo: githubRepositoryPath, #branch: "$j", _})
+								\(rerunLatestWorkflow & {#repo: trybotRepositoryPath, #branch: "$j", _})
+							done
+						done
+						"""
+				},
+			]
+		}
+	}
 }
 
 writeNetrcFile: json.#step & {

--- a/internal/ci/base/github.cue
+++ b/internal/ci/base/github.cue
@@ -20,7 +20,7 @@ installGo: json.#step & {
 	with: {
 		// We do our own caching in setupGoActionsCaches.
 		cache:        false
-		"go-version": *"${{ matrix.go-version }}" | string
+		"go-version": string
 	}
 }
 
@@ -124,11 +124,19 @@ curlGitHubAPI: #"""
 	"""#
 
 setupGoActionsCaches: {
-	// #protectedBranchExpr is a GitHub expression
-	// (https://docs.github.com/en/actions/learn-github-actions/expressions)
-	// that evaluates to true if the workflow is running for a commit against a
-	// protected branch.
-	#protectedBranchExpr: string
+	// #readonly determines whether we ever want to write the cache back. The
+	// writing of a cache back (for any given cache key) should only happen on a
+	// protected branch. But running a workflow on a protected branch often
+	// implies that we want to skip the cache to ensure we catch flakes early.
+	// Hence the concept of clearing the testcache to ensure we catch flakes
+	// early can be defaulted based on #readonly. In the general case the two
+	// concepts are orthogonal, hence they are kept as two parameters, even
+	// though in our case we could get away with a single parameter that
+	// encapsulates our needs.
+	#readonly:       *false | bool
+	#cleanTestCache: *!#readonly | bool
+	#goVersion:      string
+	#os:             string
 
 	let goModCacheDirID = "go-mod-cache-dir"
 	let goCacheDirID = "go-cache-dir"
@@ -137,6 +145,21 @@ setupGoActionsCaches: {
 	// GitHub expressions that represent the directories
 	// that participate in Go caching.
 	let cacheDirs = [ "${{ steps.\(goModCacheDirID).outputs.dir }}/cache/download", "${{ steps.\(goCacheDirID).outputs.dir }}"]
+
+	let cacheRestoreKeys = "\(#os)-\(#goVersion)"
+
+	let cacheStep = json.#step & {
+		with: {
+			path: strings.Join(cacheDirs, "\n")
+
+			// GitHub actions caches are immutable. Therefore, use a key which is
+			// unique, but allow the restore to fallback to the most recent cache.
+			// The result is then saved under the new key which will benefit the
+			// next build. Restore keys are only set if the step is restore.
+			key:            "\(cacheRestoreKeys)-${{ github.run_id }}"
+			"restore-keys": cacheRestoreKeys
+		}
+	}
 
 	// pre is the list of steps required to establish and initialise the correct
 	// caches for Go-based workflows.
@@ -153,34 +176,49 @@ setupGoActionsCaches: {
 			id:   goCacheDirID
 			run:  #"echo "dir=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}"#
 		},
-		for _, v in [
-			{
-				if:   #protectedBranchExpr
-				uses: "actions/cache@v3"
-			},
-			{
-				if:   "! \(#protectedBranchExpr)"
-				uses: "actions/cache/restore@v3"
-			},
-		] {
-			v & json.#step & {
-				with: {
-					path: strings.Join(cacheDirs, "\n")
 
-					// GitHub actions caches are immutable. Therefore, use a key which is
-					// unique, but allow the restore to fallback to the most recent cache.
-					// The result is then saved under the new key which will benefit the
-					// next build
-					key:            "${{ runner.os }}-${{ matrix.go-version }}-${{ github.run_id }}"
-					"restore-keys": "${{ runner.os }}-${{ matrix.go-version }}"
-				}
+		// Only if we are not running in readonly mode do we want a step that
+		// uses actions/cache (read and write). Even then, the use of the write
+		// step should be predicated on us running on a protected branch. Because
+		// it's impossible for anything else to write such a cache.
+		if !#readonly {
+			cacheStep & {
+				if:   isProtectedBranch
+				uses: "actions/cache@v3"
+			}
+		},
+
+		cacheStep & {
+			// If we are readonly, there is no condition on when we run this step.
+			// It should always be run, becase there is no alternative. But if we
+			// are not readonly, then we need to predicate this step on us not
+			// being on a protected branch.
+			if !#readonly {
+				if: "! \(isProtectedBranch)"
+			}
+
+			uses: "actions/cache/restore@v3"
+		},
+
+		if #cleanTestCache {
+			// All tests on protected branches should skip the test cache.  The
+			// canonical way to do this is with -count=1. However, we want the
+			// resulting test cache to be valid and current so that subsequent CLs
+			// in the trybot repo can leverage the updated cache. Therefore, we
+			// instead perform a clean of the testcache.
+			//
+			// Critically we only want to do this in the main repo, not the trybot
+			// repo.
+			json.#step & {
+				if:  "github.repository == '\(githubRepositoryPath)' && (\(isProtectedBranch) || github.ref == 'refs/heads/\(testDefaultBranch)')"
+				run: "go clean -testcache"
 			}
 		},
 	]
 }
 
-// #isProtectedBranch is an expression that evaluates to true if the
-// job is running as a result of pushing to one of _#protectedBranchPatterns.
+// isProtectedBranch is an expression that evaluates to true if the
+// job is running as a result of pushing to one of protectedBranchPatterns.
 // It would be nice to use the "contains" builtin for simplicity,
 // but array literals are not yet supported in expressions.
 isProtectedBranch: {

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -30,7 +30,7 @@ workflows: trybot: _repo.bashWorkflow & {
 
 	on: {
 		push: {
-			branches: list.Concat([["trybot/*/*", _repo.testDefaultBranch], _repo.protectedBranchPatterns]) // do not run PR branches
+			branches: list.Concat([[_repo.testDefaultBranch], _repo.protectedBranchPatterns]) // do not run PR branches
 			"tags-ignore": [_repo.releaseTagPattern]
 		}
 		pull_request: {}
@@ -38,8 +38,6 @@ workflows: trybot: _repo.bashWorkflow & {
 
 	jobs: {
 		test: {
-			"runs-on": _repo.linuxMachine
-
 			steps: [
 				for v in _repo.checkoutCode {v},
 
@@ -52,17 +50,7 @@ workflows: trybot: _repo.bashWorkflow & {
 
 				// cachePre must come after installing Node and Go, because the cache locations
 				// are established by running each tool.
-				for v in _goCaches {v},
-
-				// All tests on protected branches should skip the test cache.
-				// The canonical way to do this is with -count=1. However, we
-				// want the resulting test cache to be valid and current so that
-				// subsequent CLs in the trybot repo can leverage the updated
-				// cache. Therefore, we instead perform a clean of the testcache.
-				json.#step & {
-					if:  "github.repository == '\(_repo.githubRepositoryPath)' && (\(_repo.isProtectedBranch) || github.ref == 'refs/heads/\(_repo.testDefaultBranch)')"
-					run: "go clean -testcache"
-				},
+				for v in _setupGoActionsCaches {v},
 
 				json.#step & {
 					// The latest git clean check ensures that this call is effectively
@@ -204,4 +192,15 @@ _netlifyDeploy: json.#step & {
 	name: string
 	run:  "netlify deploy \(alias) -f \(nc.build.functions) -d \(nc.build.publish) -m \(strconv.Quote(name)) -s \(#site) --debug \(prod)"
 	env: NETLIFY_AUTH_TOKEN: "${{ secrets.NETLIFY_AUTH_TOKEN_\(uSite)}}"
+}
+
+// _setupGoActionsCaches is shared between trybot and update_tip.
+_setupGoActionsCaches: _repo.setupGoActionsCaches & {
+	#goVersion: _installGo.with."go-version"
+
+	// Unfortunate that we need to hardcode here. Ideally we would be able to derive
+	// the OS from the runner. i.e. from _linuxWorkflow somehow.
+	#os: "Linux"
+
+	_
 }

--- a/internal/ci/github/update_tip.cue
+++ b/internal/ci/github/update_tip.cue
@@ -31,10 +31,19 @@ workflows: update_tip: _repo.bashWorkflow & {
 	jobs: push: {
 		"runs-on": _repo.linuxMachine
 
+		let _setupReadonlyGoActionsCaches = _setupGoActionsCaches & {
+			#readonly: true
+			_
+		}
+
 		// Only run this workflow in the main repository, and if we are triggered
 		// by repository_dispatch (which will happen if the cue-lang/cue repo
 		// needs to tell us to rebuild tip) only do so if our payload is of
-		// the correct type.
+		// the correct type. We explicitly use the default branch here in order
+		// that the latest running of this workflow wins. If it were tied to the
+		// ref that triggered the GitHub action event, then it would be possible
+		// to cause tip.cuelang.org to go backwards in time by re-running a
+		// workflow run associated with a commit that is not the current tip.
 		if: "${{ github.repository == '\(_repo.githubRepositoryPath)' && (github.event_name != 'repository_dispatch' || github.event.client_payload.type == 'rebuild_tip') }}"
 		let _checkoutCode = _repo.checkoutCode & {
 			#actionsCheckout: {
@@ -52,7 +61,7 @@ workflows: update_tip: _repo.bashWorkflow & {
 
 			// cachePre must come after installing Node and Go, because the cache locations
 			// are established by running each tool.
-			for v in _goCaches {v},
+			for v in _setupReadonlyGoActionsCaches {v},
 
 			_tipDist,
 			_installNetlifyCLI,

--- a/internal/ci/github/workflows.cue
+++ b/internal/ci/github/workflows.cue
@@ -15,10 +15,6 @@
 // package github declares the workflows for this project.
 package github
 
-import (
-	"github.com/SchemaStore/schemastore/src/schemas/json"
-)
-
 // Note: the name of the workflows (and hence the corresponding .yml filenames)
 // correspond to the environment variable names for gerritstatusupdater.
 // Therefore, this filename must only be change in combination with also
@@ -38,12 +34,17 @@ import (
 // We explicitly use close() here instead of a definition in order that we can
 // cue export the github package as a test.
 workflows: close({
-	[string]: json.#Workflow
+	// Adding this constraint here, whilst clear for the reader,
+	// blows out evaluation time. This will be fixed as part of
+	// the performance work which is covered under various issues.
+	// [string]: json.#Workflow
 
-	(_repo.trybot.key): _
-	trybot_dispatch:    _repo.trybotDispatchWorkflow
-	update_tip:         _
-	push_tip_to_trybot: _repo.pushTipToTrybotWorkflow
+	_repo.trybotWorkflows
+
+	trybot:     _linuxWorkflow
+	update_tip: _linuxWorkflow
 })
 
-_goCaches: _repo.setupGoActionsCaches & {#protectedBranchExpr: _repo.isProtectedBranch, _}
+_linuxWorkflow: {
+	jobs: [string]: "runs-on": _repo.linuxMachine
+}


### PR DESCRIPTION
The contents of the base package are a mechanical copy from cef63a35 in
the main CUE repo.

This includes switching the base.trybotWorkflows template which
automatically gives us the evict_caches workflow to complement the now
shared Go cache strategy.

We also drop the trybot/*/* branch pattern from the trybot workflow
which has no effect and just adds noise.

The Go cache keys now reflet the fact the trybot workflow only uses a
single Go version and not a matrix.

The update_tip workflow uses the Go cache template in a readonly
capacity.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: Ic230c8e71dbde99e3f621ea6e66d48ff73bd3b3e
