### PR TITLE
all: set GONOSUMDB when grabbing latest versions

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -120,10 +120,10 @@ jobs:
         run: go clean -testcache
       - name: Ensure latest CUE
         run: |-
-          GOPROXY=direct go get -d cuelang.org/go@latest
+          GONOSUMDB=cuelang.org/go GOPROXY=direct go get -d cuelang.org/go@latest
           go mod tidy
           cd play
-          GOPROXY=direct go get -d cuelang.org/go@latest
+          GONOSUMDB=cuelang.org/go GOPROXY=direct go get -d cuelang.org/go@latest
           go mod tidy
       - name: Re-vendor play
         run: ./_scripts/revendorToolsInternal.bash

--- a/build.bash
+++ b/build.bash
@@ -14,7 +14,10 @@ fi
 # and main from github.com/cue-sh/playground dependencies
 if [ "${BRANCH:-}" = "tip" ]
 then
-	GOPROXY=direct $time go get cuelang.org/go@master
+	# We set GONOSUMDB here because we reguarly see issues when trying to go get
+	# a recent commit that index.golang.org might not yet have seen.
+	GONOSUMDB=cuelang.org/go GOPROXY=direct $time go get cuelang.org/go@master
+
 	# Now force cuelang.org/go  through the proxy so that the /pkg.go.dev redirect works
 	$time go get -d cuelang.org/go@$(go list -m -f={{.Version}} cuelang.org/go)
 	$time go mod tidy

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -68,12 +68,16 @@ workflows: trybot: _repo.bashWorkflow & {
 					// The latest git clean check ensures that this call is effectively
 					// side effect-free. Using GOPROXY=direct ensures we don't accidentally
 					// hit a stale cache in the proxy.
+					//
+					// For that reason, we also set GONOSUMDB in order to avoid the
+					// regular issues we see with recent versions not being
+					// available yet in index.golang.org and hence the sumdb.
 					name: "Ensure latest CUE"
 					run: """
-						GOPROXY=direct go get -d cuelang.org/go@latest
+						GONOSUMDB=cuelang.org/go GOPROXY=direct go get -d cuelang.org/go@latest
 						go mod tidy
 						cd play
-						GOPROXY=direct go get -d cuelang.org/go@latest
+						GONOSUMDB=cuelang.org/go GOPROXY=direct go get -d cuelang.org/go@latest
 						go mod tidy
 						"""
 				},

--- a/play/build.bash
+++ b/play/build.bash
@@ -30,7 +30,11 @@ then
 	# to the tip of CUE and regenerate. Otherwise we do not
 	# want to regenerate (we should be relying on the files
  	# commited)
-	GOPROXY=direct $time go get cuelang.org/go@master
+	#
+	# We set GONOSUMDB here because we reguarly see issues when trying to go get
+	# a recent commit that index.golang.org might not yet have seen.
+	GONOSUMDB=cuelang.org/go GOPROXY=direct $time go get cuelang.org/go@master
+
 	$time ./_scripts/revendorToolsInternal.bash
 	$time go generate ./...
 fi


### PR DESCRIPTION
We have seen countless issues with either proxy.golang.org or
sum.golang.org when trying to go get recent commits/versions.

Side-step these issues by setting GONOSUMDB=cuelang.org/go in those
situations where we set GOPROXY=direct for such a go get.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I954f77b8aab7b49e7480fedd7e00b19293fd9d97
