### PR TITLE
all: set GOPRIVATE when grabbing latest versions

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -120,10 +120,10 @@ jobs:
         run: go clean -testcache
       - name: Ensure latest CUE
         run: |-
-          GOPROXY=direct go get -d cuelang.org/go@latest
+          GOPRIVATE=cuelang.org/go go get -d cuelang.org/go@latest
           go mod tidy
           cd play
-          GOPROXY=direct go get -d cuelang.org/go@latest
+          GOPRIVATE=cuelang.org/go go get -d cuelang.org/go@latest
           go mod tidy
       - name: Re-vendor play
         run: ./_scripts/revendorToolsInternal.bash

--- a/build.bash
+++ b/build.bash
@@ -14,7 +14,10 @@ fi
 # and main from github.com/cue-sh/playground dependencies
 if [ "${BRANCH:-}" = "tip" ]
 then
-	GOPROXY=direct $time go get cuelang.org/go@master
+	# We set GOPRIVATE here because we reguarly see issues when trying to go get
+	# a recent commit that index.golang.org might not yet have seen.
+	GOPRIVATE=cuelang.org/go $time go get cuelang.org/go@master
+
 	# Now force cuelang.org/go  through the proxy so that the /pkg.go.dev redirect works
 	$time go get -d cuelang.org/go@$(go list -m -f={{.Version}} cuelang.org/go)
 	$time go mod tidy

--- a/internal/ci/github/trybot.cue
+++ b/internal/ci/github/trybot.cue
@@ -66,14 +66,14 @@ workflows: trybot: _repo.bashWorkflow & {
 
 				json.#step & {
 					// The latest git clean check ensures that this call is effectively
-					// side effect-free. Using GOPROXY=direct ensures we don't accidentally
+					// side effect-free. Using GOPRIVATE ensures we don't accidentally
 					// hit a stale cache in the proxy.
 					name: "Ensure latest CUE"
 					run: """
-						GOPROXY=direct go get -d cuelang.org/go@latest
+						GOPRIVATE=cuelang.org/go go get -d cuelang.org/go@latest
 						go mod tidy
 						cd play
-						GOPROXY=direct go get -d cuelang.org/go@latest
+						GOPRIVATE=cuelang.org/go go get -d cuelang.org/go@latest
 						go mod tidy
 						"""
 				},

--- a/play/build.bash
+++ b/play/build.bash
@@ -30,7 +30,11 @@ then
 	# to the tip of CUE and regenerate. Otherwise we do not
 	# want to regenerate (we should be relying on the files
  	# commited)
-	GOPROXY=direct $time go get cuelang.org/go@master
+	#
+	# We set GOPRIVATE here because we reguarly see issues when trying to go get
+	# a recent commit that index.golang.org might not yet have seen.
+	GOPRIVATE=cuelang.org/go $time go get cuelang.org/go@master
+
 	$time ./_scripts/revendorToolsInternal.bash
 	$time go generate ./...
 fi


### PR DESCRIPTION
We have seen countless issues with either proxy.golang.org or
sum.golang.org when trying to go get recent commits/versions.

Side-step these issues by setting GOPRIVATE=cuelang.org/go.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I954f77b8aab7b49e7480fedd7e00b19293fd9d97
