### PR TITLE
gerritstatusupdater: add logic for handling Dispatch-Trailer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/andygrunwald/go-gerrit v0.0.0-20220917070846-2e881e2fb2b5
 	github.com/apex/gateway v1.1.2
 	github.com/aws/aws-lambda-go v1.32.1
+	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v45 v45.2.0
 	github.com/rogpeppe/testscript v1.1.0
 	golang.org/x/mod v0.6.0-dev.0.20220818022119-ed83ed61efb9

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
 github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/internal/functions/gerritstatusupdater/gerritstatusupdater.go
+++ b/internal/functions/gerritstatusupdater/gerritstatusupdater.go
@@ -79,6 +79,7 @@ package gerritstatusupdater
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -95,6 +96,9 @@ import (
 
 var (
 	dryRun = os.Getenv(EnvDryRun) != ""
+	debug  = os.Getenv(EnvDebug) != ""
+
+	errEarlyReturn = errors.New("early return in handler")
 )
 
 // Function is a type which implements net/http.Handler, a handler which
@@ -144,11 +148,20 @@ const (
 	// effectively tied to the instance of gerritstatusupdater that runs,
 	// and indeed it would be a security problem to parse the webook without
 	// first validating it.
-	EnvWebhookSecret = EnvPrefix + "WEBHOOK_SECRET"
+	EnvWebhookSecret = EnvPrefix + "_WEBHOOK_SECRET"
 
 	// EnvDryRun can be set to a non-empty string to prevent any actual "writes"
 	// happening to either GitHub and/or GerritHub.
-	EnvDryRun = EnvPrefix + "DRYRUN"
+	EnvDryRun = EnvPrefix + "_DRYRUN"
+
+	// EnvDispatchTrailerMode can be set to non-empty to set the mode of
+	// Dispatch-Trailer handling. See the documentation for the mode* constants
+	// for the values that can be set. Any value (including empty string) other
+	// than a known value will be defaulted to modeIgnore.
+	EnvDispatchTrailerMode = EnvPrefix + "_DISPATCH_TRAILER_MODE"
+
+	// EnvDebug can be set to non-empty in order to enable debug-level loggin
+	EnvDebug = EnvPrefix + "_DEBUG"
 )
 
 const (
@@ -168,6 +181,7 @@ const (
 	workflowStatusCompleted  = "completed"
 
 	workflowConclusionSuccess = "success"
+	workflowConclusionSkipped = "skipped"
 )
 
 // A localContext represents the state we build up as we receive and handle
@@ -198,6 +212,10 @@ type localContext struct {
 	// HeadBranch is the branch for which a workflow is triggered.
 	HeadBranch string `json:",omitempty"`
 
+	// FoundDispatchTrailer indicates we found a Dispatch-Trailer in the
+	// commit associated with the event
+	FoundDispatchTrailer bool `json:",omitempty"`
+
 	// EventType is the type of the webhook event
 	EventType string `json:",omitempty"`
 
@@ -212,23 +230,88 @@ type localContext struct {
 	// conclusion
 	WorkflowConclusion string `json:",omitempty"`
 
-	// ChangeID is the Change-Id of the associated CL
-	ChangeID string `json:",omitempty"`
-
-	// RevisionID is the commit hash of the associated CL corresponding to the
-	// patchset under test
-	RevisionID string `json:",omitempty"`
-
 	// CL is the string representation of the number of the associated CL
 	CL string `json:",omitempty"`
 
 	// Patchset is the string representation of the patchset number of the
 	// associated CL corresponding to the patchset under test
 	Patchset string `json:",omitempty"`
+
+	dispatchMode string
 }
 
-func (c *localContext) setHeadBranch(b string) {
-	c.HeadBranch = b
+const (
+	// For when we only want to handle the branch-based approach.
+	// This allows us to safely deploy this handler without the
+	// deployed version trying to do anything with dispatch trailers
+	// if it sees them.
+	modeIgnore = "ignore"
+
+	// For when we want to handle the branch-based approach _and_
+	// the new trailers. i.e. we're comfortable that we can turn
+	// on the handling of both in our production instance.
+	modePrefer = "prefer"
+
+	// For when we want to require that a trailer be present. i.e.
+	// turn this mode on prior to deprecating all the code that
+	// handles the branch mode
+	modeRequire = "require"
+)
+
+func (c *localContext) setWorkflowPath(p string) {
+	c.WorkflowPath = p
+
+	// The presence or lack of a value for EnvGerritHubInstanceSuffix in the
+	// environment indicates whether we want to handle a workflow's events or
+	// not. Why? Good question.  Workflow jobs can be made conditional using an
+	// "if" field. Workflows themselves cannot.  Hence a workflow run starts
+	// even if all the jobs contained by it would be skipped. Hence we receive a
+	// workflow run queued and in_progress event. We therefore cannot rely
+	// solely on the events we receive from GitHub in order to know whether a
+	// workflow run will actually do anything or not.  One expensive option
+	// would be to chain two jobs, where the second is conditional on the first
+	// running and instead use the workflow job in_progress event in order to
+	// mark the "start" of the workflow. This feels incredibly heavyweight.
+	// Instead, we can use the presence or otherwise of the gerrit instance
+	// configuration as an indiciation whether we want to handle a workflow's
+	// events at all. This is good enough for now.
+	instanceKey := envJoin(c.Repo, c.WorkflowPath, EnvGerritHubInstanceSuffix)
+	if instance := os.Getenv(instanceKey); instance == "" {
+		c.debugf("no configuration found for %s; hence ignoring events", instanceKey)
+		panic(errEarlyReturn)
+	}
+}
+
+func (c *localContext) setHeadBranch(run *github.WorkflowRun) {
+
+	if c.dispatchMode == modePrefer || c.dispatchMode == modeRequire {
+		// If we find a Dispatch-Trailer use it. Otherwise fall
+		// back to the old branch-based logic if we aren't in require
+		// mode
+
+		dt := parseDispatchTrailer(*run.HeadCommit.Message)
+		if dt == "" {
+			goto ParseFromHeadBranch
+		}
+		// Parse as JSON
+		var d dispatch
+		if err := json.Unmarshal([]byte(dt), &d); err != nil {
+			panic(fmt.Errorf("failed to parse "+dispatchTrailer+" payload %q: %w", dt, err))
+		}
+		c.CL = strconv.Itoa(d.CL)
+		c.Patchset = strconv.Itoa(d.Patchset)
+		c.FoundDispatchTrailer = true
+		return
+	}
+
+ParseFromHeadBranch:
+	// No Dispatch-Trailer trailer.
+
+	if c.dispatchMode == modeRequire {
+		panic(fmt.Errorf("failed to find %s", dispatchTrailer))
+	}
+
+	c.HeadBranch = *run.HeadBranch
 
 	// Establish variables to identify the CL from the head branch.
 	// Note the first part of the build branch is not significant
@@ -244,15 +327,37 @@ func (c *localContext) setHeadBranch(b string) {
 	headBranchParts := strings.Split(c.HeadBranch, "/")
 	switch x := len(headBranchParts); {
 	case x == 1:
-		log.Printf("nothing to do on branch %q", c.HeadBranch)
-		panic(nil) // early return from handler
+		c.debugf("nothing to do on branch %q", c.HeadBranch)
+		panic(errEarlyReturn) // early return from handler
 	case x < 5:
 		panic(fmt.Errorf("head branch %q not in expected format", c.HeadBranch))
 	}
-	c.ChangeID = headBranchParts[1]
-	c.RevisionID = headBranchParts[2]
 	c.CL = headBranchParts[3]
 	c.Patchset = headBranchParts[4]
+}
+
+func (c *localContext) debugf(format string, args ...interface{}) {
+	if !debug {
+		return
+	}
+	c.logf("debug", format, args...)
+}
+
+func (c *localContext) infof(format string, args ...interface{}) {
+	c.logf("info", format, args...)
+}
+
+func (c *localContext) errorf(format string, args ...interface{}) {
+	c.logf("error", format, args...)
+}
+
+func (c *localContext) logf(level, format string, args ...interface{}) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal context for log: %v", err))
+	}
+	args = append([]interface{}{level, b}, args...)
+	log.Printf("%s %s: "+format, args...)
 }
 
 // ServeHTTP is the implementation of the gerritstatusupdater serverless
@@ -273,6 +378,13 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var c localContext
 	c.DeliveryID = github.DeliveryID(r)
 
+	c.dispatchMode = os.Getenv(EnvDispatchTrailerMode)
+	switch c.dispatchMode {
+	case modeIgnore, modePrefer, modeRequire:
+	default:
+		c.dispatchMode = modeIgnore
+	}
+
 	// Set up simple logging that closes over certain variables
 	if os.Getenv("NETLIFY") == "true" {
 		log.SetFlags(0) // we get time information from Netlify
@@ -280,21 +392,10 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// We also get a unique prefix from Netlify, but build
 	// a context-based prefix ourselves here too.
 	log.SetPrefix("")
-	logf := func(format string, args ...interface{}) {
-		b, err := json.Marshal(c)
-		if err != nil {
-			panic(fmt.Errorf("failed to marshal context for log: %v", err))
-		}
-		args = append([]interface{}{b}, args...)
-		log.Printf("%s: "+format, args...)
-	}
 
 	defer func() {
-		switch err := recover(); err := err.(type) {
-		case error:
-			log.Printf("got an error: %v", err)
-			http.Error(w, err.Error(), 500)
-		case nil: // normal return
+		v := recover()
+		if v == errEarlyReturn || v == nil {
 			// We currently see a whole load of errors in the GitHub webhook logs:
 			//
 			//    error decoding lambda response: invalid status code returned from lambda: 0
@@ -315,13 +416,32 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// Fix this by simply writing a 200 status OK in case we return
 			// successfully.
 			w.WriteHeader(http.StatusOK)
-		default:
-			panic(err)
+			return
 		}
+
+		if err, ok := v.(error); ok {
+			c.errorf("got an error: %v", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		// Default logic
+		panic(v)
 	}()
 
-	// Validate the payload
-	payload, err := github.ValidatePayload(r, []byte(os.Getenv(EnvWebhookSecret)))
+	// Validate the payload. But first check we have a secret. The behaviour of
+	// ValidatePayload here is terrible. The default behaviour should be to fail
+	// if the user passed in a nil or empty secret slice. Instead the
+	// justification is that local development is made easier that way. From a
+	// security perspective that is terrible: because it's now too easy to
+	// accidentally pass in nil or empty slice and no validation happens. Just
+	// as has been the case for forever with gerritstatusupdater. What a
+	// disaster.
+	secret := os.Getenv(EnvWebhookSecret)
+	if secret == "" {
+		panic(fmt.Errorf("missing a webhook secret"))
+	}
+	payload, err := github.ValidatePayload(r, []byte(secret))
 	if err != nil {
 		panic(fmt.Errorf("failed to validate webhook payload: %w", err))
 	}
@@ -347,11 +467,11 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// We only care about jobs when they are in a completed state,
 		// and then anything other than success is failure.
 		if job.GetStatus() != workflowStatusCompleted || job.GetConclusion() == workflowConclusionSuccess {
-			logf("nothing to do")
+			c.debugf("nothing to do. job status != completed || conclusion == success")
 			return
 		}
 
-		ghclient, err := fn.buildGitHubClient(c.Repo)
+		ghclient, err := c.buildGitHubClient(c.Repo)
 		if err != nil {
 			panic(err)
 		}
@@ -367,7 +487,7 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			panic(fmt.Errorf("failed to get workflow run for id %v: %w", github.Stringify(job.RunID), err))
 		}
 
-		c.setHeadBranch(*wr.HeadBranch)
+		c.setHeadBranch(wr)
 
 		// The workflowRun does not include information like path about the workflow
 		// itself, so we need to get that too.
@@ -375,8 +495,8 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			panic(fmt.Errorf("failed to get workflow for id %v: %w", github.Stringify(wr.WorkflowID), err))
 		}
-		c.WorkflowPath = *wf.Path
-		workflowName = *wf.Name
+		c.setWorkflowPath(*wf.Path)
+		workflowName = requireEnv(c.Repo, c.WorkflowPath, "LABEL")
 
 		// Tidy up context
 		cancel()
@@ -388,18 +508,18 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		c.Repo = *event.Repo.FullName
 		c.WorkflowRunID = run.ID
-		c.setHeadBranch(*run.HeadBranch)
-		c.WorkflowPath = *event.Workflow.Path
+		c.setHeadBranch(run)
+		c.setWorkflowPath(*event.Workflow.Path)
 		c.EventAction = event.GetAction()
 		c.EventType = "workflow run"
 		c.WorkflowConclusion = run.GetConclusion()
 		c.WorkflowStatus = run.GetStatus()
+		workflowName = requireEnv(c.Repo, c.WorkflowPath, "LABEL")
 
-		ghclient, err := fn.buildGitHubClient(c.Repo)
+		ghclient, err := c.buildGitHubClient(c.Repo)
 		if err != nil {
 			panic(err)
 		}
-		workflowName = *event.Workflow.Name
 
 		// We only care about the start of a workflow or its completion.
 		//
@@ -437,16 +557,22 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			// Log workflow run status and conclusion for information purposes (will
 			// help to confirm when GitHub have fixed the state bug).
-			logf("start of workflow run")
+			c.debugf("start of workflow run")
 		case eventActionCompleted:
+			// If the conclusion is skipped, we have nothing to do
+			if run.GetConclusion() == workflowConclusionSkipped {
+				c.debugf("skipping because conclusion is " + workflowConclusionSkipped)
+				panic(errEarlyReturn)
+			}
+
 			// Best-efforts delete build branch regardless of conclusion because
 			// this is the end of the workflow run. If this fails the worst that
 			// will happen is that we build up old build branches. More important
 			// though that we update the CL.
-			if !dryRun {
+			if !dryRun && !c.FoundDispatchTrailer {
 				_, err := ghclient.Git.DeleteRef(context.Background(), path.Dir(c.Repo), path.Base(c.Repo), "heads/"+c.HeadBranch)
 				if err != nil {
-					logf("failed to delete branch: %v", err)
+					c.infof("failed to delete branch: %v", err)
 				}
 			}
 
@@ -471,13 +597,13 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			default:
 				// Given the current GitHub bug, no idea what combination of states
 				// and conclusions we might see here. Log for information
-				logf("nothing to do (workflow jobs already reported)")
+				c.debugf("nothing to do (workflow jobs already reported)")
 				return
 			}
 
 			// Log workflow run status and conclusion for information purposes (will
 			// help to confirm when GitHub have fixed the state bug).
-			logf("end of workflow run")
+			c.debugf("end of workflow run")
 
 			// success
 			msg = fmt.Sprintf("%s run succeeded: %s", workflowName, *run.HTMLURL)
@@ -491,9 +617,6 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			//
 			netlifyEnv := envJoin(c.Repo, c.WorkflowPath, "NETLIFY")
 			if previewURL, ok := os.LookupEnv(netlifyEnv); ok {
-				if c.CL == "" || c.Patchset == "" {
-					panic(fmt.Errorf("head branch %q not in expected format for netlify configuration", c.HeadBranch))
-				}
 				varRepl := func(k string) string {
 					switch k {
 					case "CL":
@@ -509,24 +632,19 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 
 		default:
-			logf("ignoring")
+			c.debugf("ignoring; workflow run event action is neither requested nor completed")
 			return
 		}
 	case *github.PingEvent:
-		logf("ping event; ignoring")
+		c.debugf("ping event; ignoring")
 		return
 	default:
 		panic(fmt.Errorf("unhandled event type %T", event))
 	}
 
-	// Build a GerritHub client
-	client, err := fn.buildGerritHubClient(c.Repo, c.WorkflowPath)
+	client, err := c.buildGerritHubClient(c.Repo, c.WorkflowPath)
 	if err != nil {
 		panic(err)
-	}
-	if client == nil {
-		logf("no configuration specified for repo-workflowPath %q", envJoin(c.Repo, c.WorkflowPath, ""))
-		return
 	}
 
 	ri := &gerrit.ReviewInput{
@@ -552,7 +670,7 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// In particular, when backporting by cherry-picking a CL into a release branch,
 	// the two CLs will share the same Change-Id trailer,
 	// but they will still have different CL numbers.
-	logf("gerrit.SetReview %s/%s with\n%s", c.CL, c.Patchset, b)
+	c.infof("gerrit.SetReview %s/%s with\n%s", c.CL, c.Patchset, b)
 	if !dryRun {
 		if _, _, err := client.Changes.SetReview(c.CL, c.Patchset, ri); err != nil {
 			panic(fmt.Errorf("failed to update gerrit: %w", err))
@@ -564,13 +682,9 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // given repo from the environment. If environment configuration cannot be
 // found for repo, an error is returned (because in this case
 // gerritstatusupdater should not be configured to listen to that repo).
-func (fn Function) buildGitHubClient(repo string) (*github.Client, error) {
+func (c *localContext) buildGitHubClient(repo string) (*github.Client, error) {
 	// Lookup GitHub access token from the env of this repo
-	githubPATKey := envJoin(repo, EnvGitHubPATSuffix)
-	githubPAT := os.Getenv(githubPATKey)
-	if githubPAT == "" {
-		return nil, fmt.Errorf("empty GitHub access token for repo %q via %q", repo, githubPATKey)
-	}
+	githubPAT := requireNonEmptyEnv(repo, EnvGitHubPATSuffix)
 
 	// Build a GitHub client
 	ts := oauth2.StaticTokenSource(
@@ -584,27 +698,15 @@ func (fn Function) buildGitHubClient(repo string) (*github.Client, error) {
 // configuration available for the supplied repo+workflowPath arguments,
 // otherwise it returns nil. If there is an error in building the client, that
 // error is returned.
-func (fn Function) buildGerritHubClient(repo, workflowPath string) (*gerrit.Client, error) {
-	// Lookup GerritHub instance from the env for this repo
-	instanceKey := envJoin(repo, workflowPath, EnvGerritHubInstanceSuffix)
-	instance := os.Getenv(instanceKey)
-	if instance == "" {
-		return nil, nil
-	}
+func (c *localContext) buildGerritHubClient(repo, workflowPath string) (*gerrit.Client, error) {
+	// Given the check in setWorkflowPath we know we must have a value here
+	instance := requireNonEmptyEnv(repo, workflowPath, EnvGerritHubInstanceSuffix)
 
 	// Lookup GerritHub username from the env for this repo
-	usernameKey := envJoin(repo, workflowPath, EnvGerritHubUsernameSuffix)
-	username := os.Getenv(usernameKey)
-	if username == "" {
-		return nil, nil
-	}
+	username := requireNonEmptyEnv(repo, workflowPath, EnvGerritHubUsernameSuffix)
 
 	// Lookup GerritHub password from the env for this repo
-	passwordKey := envJoin(repo, workflowPath, EnvGerritHubPasswordSuffix)
-	password := os.Getenv(passwordKey)
-	if password == "" {
-		return nil, nil
-	}
+	password := requireNonEmptyEnv(repo, workflowPath, EnvGerritHubPasswordSuffix)
 
 	// create GerritHub client
 	client, err := gerrit.NewClient(instance, nil)
@@ -623,5 +725,25 @@ func envJoin(parts ...string) string {
 	res = strings.ReplaceAll(res, ".", "_")
 	res = strings.ReplaceAll(res, "-", "_")
 	res = strings.ReplaceAll(res, "/", "_")
+	return res
+}
+
+func requireEnv(parts ...string) string {
+	return requireImpl(true, parts...)
+}
+
+func requireNonEmptyEnv(parts ...string) string {
+	return requireImpl(false, parts...)
+}
+
+func requireImpl(allowEmpty bool, parts ...string) string {
+	v := envJoin(parts...)
+	res, ok := os.LookupEnv(v)
+
+	// If we failed to find a value at all, or if
+	// we do not allowEmpty and res == "" then error
+	if !ok || (!allowEmpty && res == "") {
+		panic(fmt.Errorf("no configuration specified for %q", v))
+	}
 	return res
 }

--- a/internal/functions/gerritstatusupdater/trailers.go
+++ b/internal/functions/gerritstatusupdater/trailers.go
@@ -1,0 +1,74 @@
+// Copyright 2023 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gerritstatusupdater
+
+import (
+	"strings"
+)
+
+// parseDispatchTrailer attempts to parse a trailer value for the
+// key Dispatch-Trailer from commitMsg. This is a very crude
+// approximation of the real git logic. If the trailer is found
+// the value for that trailer will be returned. Otherwise an empty
+// string is returned.
+func parseDispatchTrailer(commitMsg string) string {
+	// First search for a Dispatch-Trailer trailer. If we find one
+	// use that instead of inspecting the branch.
+
+	// Following the logic of git interpret-trailers --help. We crudely search for
+	// a Dispatch-Trailer.
+
+	// Drop any trailing newlines to not confuse the search for the trailers section
+	commitMsg = strings.TrimRight(commitMsg, "\n")
+
+	// Trailers are the last block after a clear line. They are line-separated
+	// unless a trailer continues on the next line, which is achieved by adding
+	// as space at the start of the continuation line.
+	parts := strings.Split(commitMsg, "\n\n")
+
+	if len(parts) == 1 {
+		// We didn't find a trailer section using our crude approximation
+		return ""
+	}
+
+	trailers := strings.Split(parts[len(parts)-1], "\n")
+
+	// Search in reverse order to find the effective Dispatch-Trailer if there
+	// are multiple of them. For our crude search we ignore continuation lines
+	// because we know that a Dispatch-Trailer will be on a single line.
+	for i := len(trailers) - 1; i >= 0; i-- {
+		t := trailers[i]
+		if strings.HasPrefix(t, dispatchTrailer+": {\"type\":\"") {
+			lineParts := strings.SplitN(t, " ", 2)
+			return lineParts[1]
+		}
+	}
+
+	return ""
+}
+
+// NOTE: keep this consistent with the CUE value
+// cuelang.org/go/internal/ci/base.dispatchTrailer
+const dispatchTrailer = "Dispatch-Trailer"
+
+// NOTE: keep consistent with CUE schema
+// cuelang.org/go/internal/ci/base.#dispatch
+type dispatch struct {
+	Type         string `json:"type"`
+	CL           int    `json:"CL"`
+	Patchset     int    `json:"patchset"`
+	TargetBranch string `json:"targetBranch"`
+	Ref          string `json:"ref"`
+}

--- a/internal/functions/gerritstatusupdater/trailers_test.go
+++ b/internal/functions/gerritstatusupdater/trailers_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gerritstatusupdater
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseDispatchTrailer(t *testing.T) {
+	testCases := []struct {
+		key string
+		in  string
+		out string
+	}{
+		{
+			key: "contains trailer",
+			in: `
+internal/ci: baseline against main CUE repo post CI changes
+
+Signed-off-by: Paul Jolly <paul@myitcv.io>
+Change-Id: I2a5f477367fbb94c7eb3a7657cfbfb642a72a8cb
+Dispatch-Trailer: {"type":"trybot","CL":551434,"patchset":30,"targetBranch":"master","ref":"refs/changes/34/551434/30"}
+			`,
+			out: `{"type":"trybot","CL":551434,"patchset":30,"targetBranch":"master","ref":"refs/changes/34/551434/30"}`,
+		},
+		{
+			key: "no trailers",
+			in: `
+internal/ci: baseline against main CUE repo post CI changes
+
+			`,
+			out: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.key, func(t *testing.T) {
+			got := parseDispatchTrailer(tc.in)
+			want := tc.out
+			if got != want {
+				t.Error(cmp.Diff(got, want))
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
If we receive an event for a commit that contains a Dispatch-Trailer,
then decode that trailer in preference to trying to parse information
from the branch name for the event.

There is a lot going on in this CL. Ideally it would have been split
into separate CLs for easier review etc. However, we have no
unit/integration tests for gerritstatusupdater. The only way we can test
the thing is to hook it up locally using ngrok and fire some events
through it with real CI builds on GitHub. Splitting up this CL into
multiple CLs would have required doing that manual testing many times
over. So hopefully the assurance that this has been tested heavily
locally, in all three modes of GERRITSTATUSUPDATER_DISPATCH_TRAILER_MODE
is sufficient assurance.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I3a3a5a9b4e4efd3745e67b9ebd32badb950d95f5
